### PR TITLE
Allow SDT in table cells

### DIFF
--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -2,7 +2,7 @@ use derive_more::From;
 use strong_xml::{XmlRead, XmlWrite};
 
 use crate::__xml_test_suites;
-use crate::document::{Paragraph, Table};
+use crate::document::{Paragraph, Table, TableCell};
 use crate::formatting::SectionProperty;
 
 use super::SDT;
@@ -34,6 +34,7 @@ impl<'a> Body<'a> {
                 BodyContent::Table(_) => None,
                 BodyContent::SectionProperty(_) => None,
                 BodyContent::Sdt(_) => None,
+                BodyContent::TableCell(_) => None
             })
             .flatten()
             .map(|t| t.to_string())
@@ -63,6 +64,7 @@ impl<'a> Body<'a> {
                 BodyContent::Table(_) => {}
                 BodyContent::SectionProperty(_) => {}
                 BodyContent::Sdt(_) => {}
+                BodyContent::TableCell(_) => {}
             }
         }
         Ok(())
@@ -99,6 +101,8 @@ pub enum BodyContent<'a> {
     Sdt(SDT<'a>),
     #[xml(tag = "w:sectPr")]
     SectionProperty(SectionProperty<'a>),
+    #[xml(tag = "w:tc")]
+    TableCell(TableCell<'a>)
 }
 
 __xml_test_suites!(

--- a/src/document/sdt.rs
+++ b/src/document/sdt.rs
@@ -89,7 +89,7 @@ pub struct SDTEndProperty {}
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:sdtContent")]
 pub struct SDTContent<'a> {
-    #[xml(child = "w:p", child = "w:tbl", child = "w:sectPr", child = "w:sdt")]
+    #[xml(child = "w:p", child = "w:tc", child = "w:tbl", child = "w:sectPr", child = "w:sdt")]
     pub content: Vec<BodyContent<'a>>,
 }
 

--- a/src/document/table_cell.rs
+++ b/src/document/table_cell.rs
@@ -14,10 +14,10 @@ use crate::{__setter, __xml_test_suites, document::Paragraph, formatting::TableC
 ///
 /// let cell = TableCell::from(Paragraph::default());
 ///
-/// let cell = TableCell::pargraph(Paragraph::default())
+/// let cell = TableCell::paragraph(Paragraph::default())
 ///     .property(TableCellProperty::default());
 /// ```
-#[derive(Debug, XmlRead, XmlWrite, Clone)]
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:tc")]
 pub struct TableCell<'a> {
@@ -30,7 +30,7 @@ pub struct TableCell<'a> {
 impl<'a> TableCell<'a> {
     __setter!(property: TableCellProperty);
 
-    pub fn pargraph<T: Into<Paragraph<'a>>>(par: T) -> Self {
+    pub fn paragraph<T: Into<Paragraph<'a>>>(par: T) -> Self {
         TableCell {
             property: TableCellProperty::default(),
             content: vec![TableCellContent::Paragraph(par.into())],

--- a/src/document/table_row.rs
+++ b/src/document/table_row.rs
@@ -1,6 +1,8 @@
 #![allow(unused_must_use)]
 use std::borrow::Cow;
 
+use super::SDT;
+
 use strong_xml::{XmlRead, XmlWrite};
 
 use crate::{__setter, __xml_test_suites, document::TableCell, formatting::TableRowProperty};
@@ -25,31 +27,51 @@ use crate::{__setter, __xml_test_suites, document::TableCell, formatting::TableR
 pub struct TableRow<'a> {
     #[xml(default, child = "w:trPr")]
     pub property: TableRowProperty,
-    #[xml(child = "w:tc")]
-    pub cells: Vec<TableCell<'a>>,
+    #[xml(child = "w:tc", child = "w:sdt")]
+    pub cells: Vec<TableRowContent<'a>>,
+}
+
+#[derive(Debug, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum TableRowContent<'a> {
+    #[xml(tag = "w:tc")]
+    TableCell(TableCell<'a>),
+    #[xml(tag = "w:sdt")]
+    SDT(SDT<'a>)
 }
 
 impl<'a> TableRow<'a> {
     __setter!(property: TableRowProperty);
 
-    pub fn push_cell<T: Into<TableCell<'a>>>(mut self, cell: T) -> Self {
+    pub fn push_cell<T: Into<TableRowContent<'a>>>(mut self, cell: T) -> Self {
         self.cells.push(cell.into());
         self
     }
 
+    
     pub fn iter_text(&self) -> impl Iterator<Item = &Cow<'a, str>> {
         self.cells
             .iter()
-            .filter_map(|content| Some(content.iter_text()))
+            .filter_map(|content| match content {
+                //Some(content.iter_text())
+                TableRowContent::TableCell(tc) => Some(tc.iter_text()),
+                TableRowContent::SDT(_) => None
+            })
             .flatten()
     }
-
+    
+    
     pub fn iter_text_mut(&mut self) -> impl Iterator<Item = &mut Cow<'a, str>> {
         self.cells
             .iter_mut()
-            .filter_map(|content| Some(content.iter_text_mut()))
+            .filter_map(|content| match content {
+                //Some(content.iter_text_mut())
+                TableRowContent::TableCell(tc) => Some(tc.iter_text_mut()),
+                TableRowContent::SDT(_) => None
+            })
             .flatten()
     }
+    
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Current code for #2 . This gives docx-parser the ability to parse SDT items in the table. 

This utilizes the new `TableRowContent<'a>` enum to achieve this.

Note that `TableCell` is located in BodyContent. Not sure if this is actually possible nor where this should go...so I will look over this sometime tomorrow. 

Additionally, a typo was corrected (`pargraph` -> `paragraph`). 

Please let me know of your suggestions/if you require an example. I will provide these shortly!