### PR TITLE
Update text in headers, tables..

### DIFF
--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -59,7 +59,9 @@ impl<'a> Body<'a> {
                 BodyContent::Paragraph(p) => {
                     p.replace_text(dic)?;
                 }
-                BodyContent::Table(_) => {}
+                BodyContent::Table(t) => {
+                    t.replace_text(dic)?;
+                }
                 BodyContent::SectionProperty(_) => {}
                 BodyContent::Sdt(_) => {}
                 BodyContent::TableCell(_) => {}

--- a/src/document/header.rs
+++ b/src/document/header.rs
@@ -25,6 +25,33 @@ impl<'a> Header<'a> {
         self.content.push(content.into());
         self
     }
+    pub fn replace_text_simple<S>(&mut self, old: S, new: S)
+    where
+        S: AsRef<str>,
+    {
+        let dic = (old, new);
+        let dic = vec![dic];
+        let _d = self.replace_text(&dic);
+    }
+
+    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    where
+        S: AsRef<str> + 'b,
+        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+    {
+        for content in self.content.iter_mut() {
+            match content {
+                BodyContent::Paragraph(p) => {
+                    p.replace_text(dic)?;
+                }
+                BodyContent::Table(_) => {}
+                BodyContent::SectionProperty(_) => {}
+                BodyContent::Sdt(_) => {}
+                BodyContent::TableCell(_) => {}
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<'a> XmlWrite for Header<'a> {

--- a/src/document/table.rs
+++ b/src/document/table.rs
@@ -1,6 +1,5 @@
 #![allow(unused_must_use)]
 use std::borrow::Cow;
-
 use strong_xml::{XmlRead, XmlWrite};
 
 use crate::{
@@ -58,6 +57,17 @@ impl<'a> Table<'a> {
             .iter_mut()
             .map(|content| content.iter_text_mut())
             .flatten()
+    }
+
+    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    where
+        S: AsRef<str> + 'b,
+        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+    {
+        for row in self.rows.iter_mut() {
+            row.replace_text(dic)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/document/table_cell.rs
+++ b/src/document/table_cell.rs
@@ -54,6 +54,19 @@ impl<'a> TableCell<'a> {
             })
             .flatten()
     }
+
+    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    where
+        S: AsRef<str> + 'b,
+        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+    {
+        for content in self.content.iter_mut() {
+            if let TableCellContent::Paragraph(p) = content {
+                p.replace_text(dic)?
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<'a, T: Into<TableCellContent<'a>>> From<T> for TableCell<'a> {

--- a/src/document/table_row.rs
+++ b/src/document/table_row.rs
@@ -82,6 +82,19 @@ impl<'a> TableRow<'a> {
             })
             .flatten()
     }
+
+    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    where
+        S: AsRef<str> + 'b,
+        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+    {
+        for cell in self.cells.iter_mut() {
+            if let TableRowContent::TableCell(c) = cell {
+                c.replace_text(dic)?
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Just a quick two cents for who may need this. This PR integrates the existing text replacement methods for headers and for table content.

After parsing a docx like so:

```
let docx = match DocxFile::from_file("{path}/temp.docx") {
        Ok(file) => file,
        Err(e) => {
            eprintln!("Failed to open file: {:?}", e);
            return;
        }
    };

    let mut parsed_docx = match docx.parse() {
        Ok(parsed) => parsed,
        Err(e) => {
            eprintln!("Failed to parse file: {:?}", e);
            return;
        }
    };

```

We can replace text in the doc body and in its header(s) using a replacement hashmap, for example:

```
    // Obtain all header .xml file keys ("header1.xml...")
    // so that we can iteratively access them later
    let hkeys: Vec<String> = parsed_docx.headers.keys().cloned().collect();

    // Iterate over the replacement hashmapc
    // that contains (old, new) key-value entries
    for (key, val) in &replacement_map {
        parsed_docx.document.body.replace_text_simple(key, val);
        // For each document header, attempt to replace all
        // required text entries contained in the replacement map
        for header_key in &hkeys {
            parsed_docx
                .headers
                .get_mut(header_key)
                .expect("Replacing header text failed") 
                .replace_text_simple(key, val);
        }
    }
```

This was previously only possible for BodyContent::Paragraph, which is simply all paragraphs in the body excluding cell-based content and/or headers. 