### PR TITLE
Implement support for word/numbering.xml

### DIFF
--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -16,6 +16,7 @@ mod header;
 mod header_footer_reference;
 mod hyperlink;
 mod instrtext;
+mod numbering;
 mod paragraph;
 mod run;
 mod sdt;
@@ -31,6 +32,6 @@ mod theme;
 pub use self::{
     body::*, bookmark_end::*, bookmark_start::*, comment_range::*, comments::*, document::*,
     drawing::*, endnotes::*, field_char::*, footer::*, footnotes::*, grid_column::*, header::*,
-    header_footer_reference::*, hyperlink::*, paragraph::*, r#break::*, run::*, sdt::*, tab::*,
-    table::*, table_cell::*, table_grid::*, table_row::*, text::*, theme::*,
+    header_footer_reference::*, hyperlink::*, numbering::*, paragraph::*, r#break::*, run::*,
+    sdt::*, tab::*, table::*, table_cell::*, table_grid::*, table_row::*, text::*, theme::*,
 };

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -32,7 +32,7 @@ pub struct AbstractNum<'a> {
     #[xml(child = "w:multiLevelType")]
     pub multi_level_type: MultiLevelType<'a>,
     #[xml(child = "w:lvl")]
-    pub levels: Vec<Lvl<'a>>,
+    pub levels: Vec<Level<'a>>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
@@ -54,7 +54,7 @@ pub struct MultiLevelType<'a> {
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:lvl")]
-pub struct Lvl<'a> {
+pub struct Level<'a> {
     #[xml(attr = "w:ilvl")]
     pub ilvl: Option<isize>,
     #[xml(child = "w:numFmt")]

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -26,7 +26,7 @@ pub struct Numbering<'a> {
 #[xml(tag = "w:abstractNum")]
 pub struct AbstractNum<'a> {
     #[xml(attr = "w:abstractNumId")]
-    pub abstract_num_id: Cow<'a, str>,
+    pub abstract_num_id: Option<isize>,
     #[xml(child = "w:nsid")]
     pub nsid: Nsid<'a>,
     #[xml(child = "w:multiLevelType")]
@@ -56,7 +56,9 @@ pub struct MultiLevelType<'a> {
 #[xml(tag = "w:lvl")]
 pub struct Level<'a> {
     #[xml(attr = "w:ilvl")]
-    pub ilvl: Option<isize>,
+    pub i_level: Option<isize>,
+    #[xml(child = "w:start")]
+    pub start: Option<LevelStart>,
     #[xml(child = "w:numFmt")]
     pub number_format: Option<NumFmt<'a>>,
     #[xml(child = "w:lvlText")]
@@ -64,9 +66,9 @@ pub struct Level<'a> {
     #[xml(child = "w:lvlJc")]
     pub level_jc: Option<LevelJc<'a>>,
     #[xml(child = "w:pPr")]
-    pub w_pr: Option<PPr>,
+    pub p_pr: Option<PPr>,
     #[xml(child = "w:rPr")]
-    pub character: Option<CharacterProperty<'a>>,
+    pub r_pr: Vec<CharacterProperty<'a>>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
@@ -84,6 +86,15 @@ pub struct PPr {
 pub struct NumFmt<'a> {
     #[xml(attr = "w:val")]
     pub value: Cow<'a, str>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:start")]
+/// TODO Replace by enum NumberFormat
+pub struct LevelStart {
+    #[xml(attr = "w:val")]
+    pub value: Option<isize>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
@@ -107,19 +118,19 @@ pub struct LevelJc<'a> {
 #[xml(tag = "w:num")]
 pub struct Num<'a> {
     #[xml(attr = "w:numId")]
-    pub num_id: Cow<'a, str>,
+    pub num_id: Option<isize>,
     #[xml(child = "w:abstractNumId")]
-    pub abstract_num_id: Option<AbstractNumId<'a>>,
+    pub abstract_num_id: Option<AbstractNumId>,
     #[xml(child = "w:lvlOverride")]
-    pub lvl_overrides: Vec<LvlOverride<'a>>,
+    pub lvl_overrides: Vec<LevelOverride<'a>>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:lvlOverride")]
-pub struct LvlOverride<'a> {
+pub struct LevelOverride<'a> {
     #[xml(attr = "w:ilvl")]
-    pub ilvl: Cow<'a, str>,
+    pub i_level: Option<isize>,
     #[xml(child = "w:startOverride")]
     pub start_override: StartOverride<'a>,
 }
@@ -135,9 +146,9 @@ pub struct StartOverride<'a> {
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:abstractNumId")]
-pub struct AbstractNumId<'a> {
+pub struct AbstractNumId {
     #[xml(attr = "w:val")]
-    pub value: Cow<'a, str>,
+    pub value: Option<isize>,
 }
 
 impl<'a> XmlWrite for Numbering<'a> {

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -7,7 +7,7 @@ use hard_xml::{XmlRead, XmlResult, XmlWrite, XmlWriter};
 use std::{borrow::Cow, io::Write};
 
 use crate::{
-    formatting::{CharacterProperty, Indent},
+    formatting::{CharacterProperty, Indent, JustificationVal},
     schema::{SCHEMA_MAIN, SCHEMA_WORDML_14},
 };
 
@@ -64,7 +64,7 @@ pub struct Level<'a> {
     #[xml(child = "w:lvlText")]
     pub level_text: Option<LevelText<'a>>,
     #[xml(child = "w:lvlJc")]
-    pub level_jc: Option<LevelJc<'a>>,
+    pub justification: Option<LevelJustification>,
     #[xml(child = "w:pPr")]
     pub p_pr: Option<PPr>,
     #[xml(child = "w:rPr")]
@@ -105,12 +105,12 @@ pub struct LevelText<'a> {
     pub value: Cow<'a, str>,
 }
 
-#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[derive(Debug, XmlRead, XmlWrite, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:lvlJc")]
-pub struct LevelJc<'a> {
+pub struct LevelJustification {
     #[xml(attr = "w:val")]
-    pub value: Cow<'a, str>,
+    pub value: JustificationVal,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -132,15 +132,15 @@ pub struct LevelOverride<'a> {
     #[xml(attr = "w:ilvl")]
     pub i_level: Option<isize>,
     #[xml(child = "w:startOverride")]
-    pub start_override: StartOverride<'a>,
+    pub start_override: StartOverride,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:startOverride")]
-pub struct StartOverride<'a> {
+pub struct StartOverride {
     #[xml(attr = "w:val")]
-    pub value: Cow<'a, str>,
+    pub value: Option<isize>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -156,6 +156,10 @@ pub struct AbstractNumId {
 }
 
 impl<'a> Numbering<'a> {
+    /// Actual numberings refer to abstract numberings, and may overrule some settings.
+    /// This helper function takes an numbering id that is provided in a paragraph, looks up
+    /// the details in the numbering section and merges it with the abstract numbering to get
+    /// a complete AbstractNum object.
     pub fn numbering_details(&self, id: isize) -> Option<AbstractNum> {
         self.numberings.iter().find_map(|n| {
             if n.num_id != Some(id) || n.abstract_num_id.is_none() {

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -18,7 +18,7 @@ pub struct Numbering<'a> {
     #[xml(child = "w:abstractNum")]
     pub abstract_nums: Vec<AbstractNum<'a>>,
     #[xml(child = "w:num")]
-    pub nums: Vec<Num<'a>>,
+    pub nums: Vec<Num>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
@@ -116,19 +116,19 @@ pub struct LevelJustification {
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:num")]
-pub struct Num<'a> {
+pub struct Num {
     #[xml(attr = "w:numId")]
     pub num_id: Option<isize>,
     #[xml(child = "w:abstractNumId")]
     pub abstract_num_id: Option<AbstractNumId>,
     #[xml(child = "w:lvlOverride")]
-    pub lvl_overrides: Vec<LevelOverride<'a>>,
+    pub lvl_overrides: Vec<LevelOverride>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:lvlOverride")]
-pub struct LevelOverride<'a> {
+pub struct LevelOverride {
     #[xml(attr = "w:ilvl")]
     pub i_level: Option<isize>,
     #[xml(child = "w:startOverride")]

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -1,0 +1,163 @@
+//! Comments part
+//!
+//! The corresponding ZIP item is `/word/numbering.xml`.
+#![allow(unused_must_use)]
+
+use hard_xml::{XmlRead, XmlResult, XmlWrite, XmlWriter};
+use std::{borrow::Cow, io::Write};
+
+use crate::{
+    formatting::{CharacterProperty, Indent},
+    schema::{SCHEMA_MAIN, SCHEMA_WORDML_14},
+};
+
+#[derive(Debug, Default, XmlRead, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:numbering")]
+pub struct Numbering<'a> {
+    #[xml(child = "w:abstractNum")]
+    pub abstract_nums: Vec<AbstractNum<'a>>,
+    #[xml(child = "w:num")]
+    pub nums: Vec<Num<'a>>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:abstractNum")]
+pub struct AbstractNum<'a> {
+    #[xml(attr = "w:abstractNumId")]
+    pub abstract_num_id: Cow<'a, str>,
+    #[xml(child = "w:nsid")]
+    pub nsid: Nsid<'a>,
+    #[xml(child = "w:multiLevelType")]
+    pub multi_level_type: MultiLevelType<'a>,
+    #[xml(child = "w:lvl")]
+    pub levels: Vec<Lvl<'a>>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:nsid")]
+pub struct Nsid<'a> {
+    #[xml(attr = "w:val")]
+    pub value: Cow<'a, str>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:multiLevelType")]
+pub struct MultiLevelType<'a> {
+    #[xml(attr = "w:val")]
+    pub value: Cow<'a, str>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:lvl")]
+pub struct Lvl<'a> {
+    #[xml(attr = "w:ilvl")]
+    pub ilvl: Option<isize>,
+    #[xml(child = "w:numFmt")]
+    pub number_format: Option<NumFmt<'a>>,
+    #[xml(child = "w:lvlText")]
+    pub level_text: Option<LevelText<'a>>,
+    #[xml(child = "w:lvlJc")]
+    pub level_jc: Option<LevelJc<'a>>,
+    #[xml(child = "w:pPr")]
+    pub w_pr: Option<PPr>,
+    #[xml(child = "w:rPr")]
+    pub character: Option<CharacterProperty<'a>>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:pPr")]
+pub struct PPr {
+    #[xml(child = "w:ind")]
+    pub indent: Option<Indent>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:numFmt")]
+/// TODO Replace by enum NumberFormat
+pub struct NumFmt<'a> {
+    #[xml(attr = "w:val")]
+    pub value: Cow<'a, str>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:lvlText")]
+pub struct LevelText<'a> {
+    #[xml(attr = "w:val")]
+    pub value: Cow<'a, str>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:lvlJc")]
+pub struct LevelJc<'a> {
+    #[xml(attr = "w:val")]
+    pub value: Cow<'a, str>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:num")]
+pub struct Num<'a> {
+    #[xml(attr = "w:numId")]
+    pub num_id: Cow<'a, str>,
+    #[xml(child = "w:abstractNumId")]
+    pub abstract_num_id: Option<AbstractNumId<'a>>,
+    #[xml(child = "w:lvlOverride")]
+    pub lvl_overrides: Vec<LvlOverride<'a>>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:lvlOverride")]
+pub struct LvlOverride<'a> {
+    #[xml(attr = "w:ilvl")]
+    pub ilvl: Cow<'a, str>,
+    #[xml(child = "w:startOverride")]
+    pub start_override: StartOverride<'a>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:startOverride")]
+pub struct StartOverride<'a> {
+    #[xml(attr = "w:val")]
+    pub value: Cow<'a, str>,
+}
+
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "w:abstractNumId")]
+pub struct AbstractNumId<'a> {
+    #[xml(attr = "w:val")]
+    pub value: Cow<'a, str>,
+}
+
+impl<'a> XmlWrite for Numbering<'a> {
+    fn to_writer<W: Write>(&self, writer: &mut XmlWriter<W>) -> XmlResult<()> {
+        log::debug!("[Numbering] Started writing.");
+
+        let _ = write!(writer.inner, "{}", crate::schema::SCHEMA_XML);
+
+        writer.write_element_start("w:numbering")?;
+
+        writer.write_attribute("xmlns:w", SCHEMA_MAIN)?;
+
+        writer.write_attribute("xmlns:w14", SCHEMA_WORDML_14)?;
+
+        writer.write_element_end_open()?;
+
+        writer.write_element_end_close("w:comments")?;
+
+        log::debug!("[Comments] Finished writing.");
+
+        Ok(())
+    }
+}

--- a/src/formatting/indent.rs
+++ b/src/formatting/indent.rs
@@ -28,6 +28,8 @@ pub struct Indent {
     pub first_line_chars: Option<isize>,
     #[xml(attr = "w:firstLine")]
     pub first_line: Option<isize>,
+    #[xml(attr = "w:hanging")]
+    pub hanging: Option<isize>,
 }
 
 impl Indent {

--- a/src/formatting/paragraph_property.rs
+++ b/src/formatting/paragraph_property.rs
@@ -121,7 +121,7 @@ pub struct ParagraphProperty<'a> {
     #[xml(child = "w:cnfStyle")]
     pub cnf_style: Option<CnfStyle<'a>>,
     #[xml(child = "w:rPr")]
-    pub r_pr: Option<super::CharacterProperty<'a>>,
+    pub r_pr: Vec<super::CharacterProperty<'a>>,
     #[xml(child = "w:sectPr")]
     pub section_property: Option<SectionProperty<'a>>,
     #[xml(child = "w:pPrChange")]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -51,6 +51,8 @@ pub const SCHEMA_IMAGE: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
 pub const SCHEMA_COMMENTS: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments";
+pub const SCHEMA_NUMBERING: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering";
 
 pub const SCHEMA_COMMENTS_EXT: &str =
     "http://schemas.microsoft.com/office/2018/08/relationships/commentsExtensible";


### PR DESCRIPTION
When a docx uses lists (bullets, numbered lists), the numbering style is defined in a separate numbering.xml document. This PR reads the XML, parses it, and writes it out again. It includes a few tests too.