### PR TITLE
Add support for hyperlinks and relationship.target_mode

### DIFF
--- a/src/docx.rs
+++ b/src/docx.rs
@@ -400,13 +400,13 @@ impl DocxFile {
             }
         }
 
-        let themes = HashMap::new();
+        let mut themes = HashMap::new();
         // turn off for now
-        // for t in self.themes.iter() {
-        //     let th = Theme::from_str(&t.1)?;
-        //     let name = t.0.replace("word/", "");
-        //     themes.insert(name, th);
-        // }
+        for t in self.themes.iter() {
+            let th = Theme::from_str(&t.1)?;
+            let name = t.0.replace("word/", "");
+            themes.insert(name, th);
+        }
 
         let content_types = ContentTypes::from_str(&self.content_types)?;
 
@@ -470,17 +470,7 @@ impl DocxFile {
             None
         };
 
-        // let web_settings = if let Some(content) = &self.web_settings {
-        //     if let Ok(ws) = WebSettings::from_str(content) {
-        //         Some(ws)
-        //     } else {
-        //         None
-        //     }
-        // } else {
-        //     None
-        // };
         let web_settings = if let Some(content) = &self.web_settings {
-            let content = content.replace("ns0:", "w:").to_string();
             Some(WebSettings::from_str(
                 &content.replace("ns0:", "w:").to_string(),
             )?)

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -430,7 +430,7 @@ impl DocxFile {
                         r2.ty.to_string().as_str(),
                         crate::schema::SCHEMA_HEADER
                             | crate::schema::SCHEMA_FOOTER
-                            //| crate::schema::SCHEMA_THEME
+                            | crate::schema::SCHEMA_THEME
                             | crate::schema::SCHEMA_FONT_TABLE
                             | crate::schema::SCHEMA_STYLES
                             | crate::schema::SCHEMA_FOOTNOTES
@@ -439,6 +439,8 @@ impl DocxFile {
                             | crate::schema::SCHEMA_WEB_SETTINGS
                             | crate::schema::SCHEMA_COMMENTS
                             | crate::schema::SCHEMA_IMAGE
+                            | crate::schema::SCHEMA_HYPERLINK
+                            | crate::schema::SCHEMA_NUMBERING
                     )
                 })
                 .map(|d| d.to_owned())

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -53,6 +53,8 @@ pub const SCHEMA_COMMENTS: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments";
 pub const SCHEMA_NUMBERING: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering";
+pub const SCHEMA_HYPERLINK: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";
 
 pub const SCHEMA_COMMENTS_EXT: &str =
     "http://schemas.microsoft.com/office/2018/08/relationships/commentsExtensible";

--- a/src/web_settings.rs
+++ b/src/web_settings.rs
@@ -101,3 +101,36 @@ __xml_test_suites!(
     )
     .as_str(),
 );
+
+#[test]
+fn regular_namespace() {
+    let alt_web_settings = r#"<?xml version="1.0" encoding="UTF-8"?>
+    <w:webSettings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:allowPNG />
+        <w:doNotSaveAsSingleFile />
+    </w:webSettings>
+    "#;
+    let web_settings = WebSettings::from_str(&alt_web_settings).unwrap();
+    assert_eq!(web_settings.allow_png, Some(AllowPNG {}));
+    assert_eq!(
+        web_settings.do_not_save_as_single_file,
+        Some(DoNotSaveAsSingleFile {})
+    );
+}
+
+#[test]
+fn alternative_namespace() {
+    let alt_web_settings = r#"<?xml version="1.0" encoding="UTF-8"?>
+    <ns0:webSettings xmlns:ns0="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <ns0:allowPNG />
+        <ns0:doNotSaveAsSingleFile />
+    </ns0:webSettings>
+    "#
+    .replace("ns0:", "w:");
+    let web_settings = WebSettings::from_str(&alt_web_settings).unwrap();
+    assert_eq!(web_settings.allow_png, Some(AllowPNG {}));
+    assert_eq!(
+        web_settings.do_not_save_as_single_file,
+        Some(DoNotSaveAsSingleFile {})
+    );
+}


### PR DESCRIPTION
- docx.document_rels.relationships may contain hyperlinks to (target_mode ==) external websites. 
- Also re-enabled support for themes. They were commented out, but tests are doing OK.
- Added integration tests for parsing hyperlinks and images.