### PR TITLE
Implement `Display` + `Error` for `DocxError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ derive_more = "0.99.17"
 log = "0.4.14"
 hard-xml = "1.27.0"
 zip = {version = "1.1.2", default-features = false, features = ["deflate"]}
+thiserror = "1"
 
 [dev-dependencies]
 env_logger = "0.11.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,32 +1,18 @@
 use std::io::Error as IOError;
 
 use hard_xml::XmlError;
+use thiserror::Error;
 use zip::result::ZipError;
 
 /// Error type of docx-rs
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum DocxError {
-    IO(IOError),
-    Xml(XmlError),
-    Zip(ZipError),
-}
-
-impl From<IOError> for DocxError {
-    fn from(err: IOError) -> Self {
-        DocxError::IO(err)
-    }
-}
-
-impl From<XmlError> for DocxError {
-    fn from(err: XmlError) -> Self {
-        DocxError::Xml(err)
-    }
-}
-
-impl From<ZipError> for DocxError {
-    fn from(err: ZipError) -> Self {
-        DocxError::Zip(err)
-    }
+    #[error("IO error: {0}")]
+    IO(#[from] IOError),
+    #[error("malformed XML: {0}")]
+    Xml(#[from] XmlError),
+    #[error("unable to unpack file: {0}")]
+    Zip(#[from] ZipError),
 }
 
 /// Specialized `Result` which the error value is `DocxError`.


### PR DESCRIPTION
Closes #14 

I've guessed error strings, let me know if you want them changing

Also, please consider: https://matklad.github.io/2022/10/24/actions-permissions.html