### PR TITLE
Make zoom percentage optional

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -362,7 +362,7 @@ pub struct Zoom {
     #[xml(attr = "w:val")]
     pub val: Option<ZoomType>,
     #[xml(attr = "w:percent")]
-    pub percent: u8,
+    pub percent: Option<u8>,
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
There are instances where zoom percentage in settings are optional for valid docx files, attached is an example where this is the case. Due to this being required in docx-rs, parsing the document will throw an error expecting the zoom percentage despite it not existing.
[zoom_percentage_optional.docx](https://github.com/user-attachments/files/16340707/zoom_percentage_optional.docx)
