### PR TITLE
Add support for extracting text from Structured Document Tags

### DIFF
--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -35,7 +35,7 @@ impl<'a> Body<'a> {
                 BodyContent::SectionProperty(_) => None,
                 BodyContent::Sdt(sdt) => Some(sdt.text()),
                 BodyContent::TableCell(_) => None,
-                BodyContent::Run(run) => Some(run.text()),
+                BodyContent::Run(_) => None,
             })
             .collect();
         v.join("\r\n")

--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -2,7 +2,7 @@ use derive_more::From;
 use hard_xml::{XmlRead, XmlWrite};
 
 use crate::__xml_test_suites;
-use crate::document::{Paragraph, Table, TableCell, Run};
+use crate::document::{Paragraph, Run, Table, TableCell};
 use crate::formatting::SectionProperty;
 
 use super::SDT;

--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -2,7 +2,7 @@ use derive_more::From;
 use hard_xml::{XmlRead, XmlWrite};
 
 use crate::__xml_test_suites;
-use crate::document::{Paragraph, Table, TableCell};
+use crate::document::{Paragraph, Table, TableCell, Run};
 use crate::formatting::SectionProperty;
 
 use super::SDT;
@@ -33,8 +33,9 @@ impl<'a> Body<'a> {
                 BodyContent::Paragraph(para) => Some(para.text()),
                 BodyContent::Table(_) => None,
                 BodyContent::SectionProperty(_) => None,
-                BodyContent::Sdt(_) => None,
+                BodyContent::Sdt(sdt) => Some(sdt.text()),
                 BodyContent::TableCell(_) => None,
+                BodyContent::Run(run) => Some(run.text()),
             })
             .collect();
         v.join("\r\n")
@@ -65,6 +66,7 @@ impl<'a> Body<'a> {
                 BodyContent::SectionProperty(_) => {}
                 BodyContent::Sdt(_) => {}
                 BodyContent::TableCell(_) => {}
+                BodyContent::Run(_) => {}
             }
         }
         Ok(())
@@ -103,6 +105,8 @@ pub enum BodyContent<'a> {
     SectionProperty(SectionProperty<'a>),
     #[xml(tag = "w:tc")]
     TableCell(TableCell<'a>),
+    #[xml(tag = "w:r")]
+    Run(Run<'a>),
 }
 
 __xml_test_suites!(

--- a/src/document/header.rs
+++ b/src/document/header.rs
@@ -48,6 +48,7 @@ impl<'a> Header<'a> {
                 BodyContent::SectionProperty(_) => {}
                 BodyContent::Sdt(_) => {}
                 BodyContent::TableCell(_) => {}
+                BodyContent::Run(_) => {}
             }
         }
         Ok(())

--- a/src/document/paragraph.rs
+++ b/src/document/paragraph.rs
@@ -95,7 +95,7 @@ impl<'a> Paragraph<'a> {
                     ParagraphContent::SDT(sdt) => Some(sdt.iter_text()),
                     _ => None,
                 })
-                .flatten()
+                .flatten(),
         )
     }
 

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -116,21 +116,19 @@ impl<'a> Run<'a> {
     }
 
     pub fn iter_text(&self) -> Box<dyn Iterator<Item = &Cow<'a, str>> + '_> {
-        Box::new(
-            self.content.iter().filter_map(|content| match content {
-                RunContent::Text(Text { text, .. }) => Some(text),
-                RunContent::InstrText(InstrText { text, .. }) => Some(text),
-                RunContent::Break(_) => None,
-                RunContent::LastRenderedPageBreak(_) => None,
-                RunContent::FieldChar(_) => None,
-                RunContent::Separator(_) => None,
-                RunContent::ContinuationSeparator(_) => None,
-                RunContent::Tab(_) => None,
-                RunContent::CarriageReturn(_) => None,
-                RunContent::Drawing(_) => None,
-                _ => None,
-            })
-        )
+        Box::new(self.content.iter().filter_map(|content| match content {
+            RunContent::Text(Text { text, .. }) => Some(text),
+            RunContent::InstrText(InstrText { text, .. }) => Some(text),
+            RunContent::Break(_) => None,
+            RunContent::LastRenderedPageBreak(_) => None,
+            RunContent::FieldChar(_) => None,
+            RunContent::Separator(_) => None,
+            RunContent::ContinuationSeparator(_) => None,
+            RunContent::Tab(_) => None,
+            RunContent::CarriageReturn(_) => None,
+            RunContent::Drawing(_) => None,
+            _ => None,
+        }))
     }
 
     pub fn iter_text_mut(&mut self) -> impl Iterator<Item = &mut Cow<'a, str>> {

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -108,20 +108,29 @@ impl<'a> Run<'a> {
         self
     }
 
-    pub fn iter_text(&self) -> impl Iterator<Item = &Cow<'a, str>> {
-        self.content.iter().filter_map(|content| match content {
-            RunContent::Text(Text { text, .. }) => Some(text),
-            RunContent::InstrText(InstrText { text, .. }) => Some(text),
-            RunContent::Break(_) => None,
-            RunContent::LastRenderedPageBreak(_) => None,
-            RunContent::FieldChar(_) => None,
-            RunContent::Separator(_) => None,
-            RunContent::ContinuationSeparator(_) => None,
-            RunContent::Tab(_) => None,
-            RunContent::CarriageReturn(_) => None,
-            RunContent::Drawing(_) => None,
-            _ => None,
-        })
+    pub fn text(&self) -> String {
+        self.iter_text()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    pub fn iter_text(&self) -> Box<dyn Iterator<Item = &Cow<'a, str>> + '_> {
+        Box::new(
+            self.content.iter().filter_map(|content| match content {
+                RunContent::Text(Text { text, .. }) => Some(text),
+                RunContent::InstrText(InstrText { text, .. }) => Some(text),
+                RunContent::Break(_) => None,
+                RunContent::LastRenderedPageBreak(_) => None,
+                RunContent::FieldChar(_) => None,
+                RunContent::Separator(_) => None,
+                RunContent::ContinuationSeparator(_) => None,
+                RunContent::Tab(_) => None,
+                RunContent::CarriageReturn(_) => None,
+                RunContent::Drawing(_) => None,
+                _ => None,
+            })
+        )
     }
 
     pub fn iter_text_mut(&mut self) -> impl Iterator<Item = &mut Cow<'a, str>> {

--- a/src/document/sdt.rs
+++ b/src/document/sdt.rs
@@ -119,18 +119,10 @@ pub struct SDTContent<'a> {
 
 impl<'a> SDTContent<'a> {
     pub fn text(&self) -> String {
-        let v: Vec<_> = self.content
-            .iter()
-            .filter_map(|content| match content {
-                BodyContent::Paragraph(para) => Some(para.text()),
-                BodyContent::Table(_) => None,
-                BodyContent::SectionProperty(_) => None,
-                BodyContent::Sdt(sdt) => Some(sdt.text()),
-                BodyContent::TableCell(_) => None,
-                BodyContent::Run(run) => Some(run.text())
-            })
-            .collect();
-            v.join("\r\n")
+        self.iter_text()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join("")
     }
 
     pub fn iter_text(&self) -> Box<dyn Iterator<Item = &Cow<'a, str>> + '_> {

--- a/src/document/sdt.rs
+++ b/src/document/sdt.rs
@@ -42,7 +42,7 @@ impl<'a> SDT<'a> {
                 .as_ref()
                 .map(|content| content.iter_text())
                 .into_iter()
-                .flatten()
+                .flatten(),
         )
     }
 
@@ -112,7 +112,7 @@ pub struct SDTContent<'a> {
         child = "w:tbl",
         child = "w:sectPr",
         child = "w:sdt",
-        child = "w:r",
+        child = "w:r"
     )]
     pub content: Vec<BodyContent<'a>>,
 }
@@ -127,15 +127,17 @@ impl<'a> SDTContent<'a> {
 
     pub fn iter_text(&self) -> Box<dyn Iterator<Item = &Cow<'a, str>> + '_> {
         Box::new(
-            self.content.iter().filter_map(|content| match content {
-                BodyContent::Paragraph(para) => Some(para.iter_text()),
-                BodyContent::Table(_) => None,
-                BodyContent::SectionProperty(_) => None,
-                BodyContent::Sdt(sdt) => Some(sdt.iter_text()),
-                BodyContent::TableCell(_) => None,
-                BodyContent::Run(run) => Some(run.iter_text()),
-            })
-            .flatten()
+            self.content
+                .iter()
+                .filter_map(|content| match content {
+                    BodyContent::Paragraph(para) => Some(para.iter_text()),
+                    BodyContent::Table(_) => None,
+                    BodyContent::SectionProperty(_) => None,
+                    BodyContent::Sdt(sdt) => Some(sdt.iter_text()),
+                    BodyContent::TableCell(_) => None,
+                    BodyContent::Run(run) => Some(run.iter_text()),
+                })
+                .flatten(),
         )
     }
 }


### PR DESCRIPTION
I initially noticed this issue because text wasn't being extracted from content control blocks that are sometimes used in forms folks create. This enables that extraction by implementing a `text` and `iter_text` function for SDT and SDTContent types.

There are a couple of observed cases that are accounted for here:
- sdtContent tags contain paragraph tags directly
- sdtContent tags contain row tags directly
- sdtContent tags contain sdt tags (and subsequently another sdtContent tag, which falls into one of these 3 cases)