### PR TITLE
Make graphic data children more generic

### DIFF
--- a/src/document/drawing.rs
+++ b/src/document/drawing.rs
@@ -267,8 +267,9 @@ pub struct Graphic<'a> {
 pub struct GraphicData<'a> {
     #[xml(default, attr = "uri")]
     pub uri: Cow<'a, str>,
+    // graphic data can have any element in any namespace as a child
     #[xml(child = "pic:pic")]
-    pub pic: Picture<'a>,
+    pub children: Vec<Picture<'a>>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -115,14 +115,17 @@ fn read_image() {
 
                                             if let Some(graphic) = inline.graphic {
                                                 if let Some(cnvpr) =
-                                                    graphic.data.pic.nv_pic_pr.c_nv_pr
+                                                    &graphic.data.children[0].nv_pic_pr.c_nv_pr
                                                 {
-                                                    assert_eq!("lalune.jpg", cnvpr.descr.unwrap());
+                                                    assert_eq!(
+                                                        "lalune.jpg",
+                                                        cnvpr.clone().descr.unwrap()
+                                                    );
                                                     assert_eq!(22, cnvpr.id.unwrap());
                                                 }
                                                 assert_eq!(
                                                     "rId20",
-                                                    graphic.data.pic.fill.blip.embed
+                                                    graphic.data.children[0].fill.blip.embed
                                                 );
                                                 if let Some(relationships) = &docx.document_rels {
                                                     if let Some(target) =


### PR DESCRIPTION
Graphic data can have children of all kinds. Documentation here: https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.graphicdata?view=openxml-3.0.1#:~:text=Any%20element%20in%20any%20namespace

All allowed types: https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.linq.a.graphicdata?view=openxml-3.0.1#documentformat-openxml-linq-a-graphicdata