### PR TITLE
Allow borrowed dictionary in `replace_text`

### DIFF
--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -1,5 +1,6 @@
 use derive_more::From;
 use hard_xml::{XmlRead, XmlWrite};
+use std::borrow::Borrow;
 
 use crate::__xml_test_suites;
 use crate::document::{Paragraph, Run, Table, TableCell};
@@ -45,15 +46,14 @@ impl<'a> Body<'a> {
     where
         S: AsRef<str>,
     {
-        let dic = (old, new);
-        let dic = vec![dic];
-        let _d = self.replace_text(&dic);
+        let _d = self.replace_text(&[(old, new)]);
     }
 
-    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    pub fn replace_text<'b, I, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
     where
         S: AsRef<str> + 'b,
-        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+        T: IntoIterator<Item = I> + Copy,
+        I: Borrow<(S, S)>,
     {
         for content in self.content.iter_mut() {
             match content {

--- a/src/document/header.rs
+++ b/src/document/header.rs
@@ -4,6 +4,7 @@
 //!
 
 use hard_xml::{XmlRead, XmlResult, XmlWrite, XmlWriter};
+use std::borrow::Borrow;
 use std::io::Write;
 
 use crate::__xml_test_suites;
@@ -29,15 +30,14 @@ impl<'a> Header<'a> {
     where
         S: AsRef<str>,
     {
-        let dic = (old, new);
-        let dic = vec![dic];
-        let _d = self.replace_text(&dic);
+        let _d = self.replace_text(&[(old, new)]);
     }
 
-    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    pub fn replace_text<'b, I, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
     where
         S: AsRef<str> + 'b,
-        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+        T: IntoIterator<Item = I> + Copy,
+        I: Borrow<(S, S)>,
     {
         for content in self.content.iter_mut() {
             match content {

--- a/src/document/paragraph.rs
+++ b/src/document/paragraph.rs
@@ -1,7 +1,7 @@
 #![allow(unused_must_use)]
 use derive_more::From;
 use hard_xml::{XmlRead, XmlWrite};
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 
 use crate::{
     __setter, __xml_test_suites,
@@ -110,10 +110,11 @@ impl<'a> Paragraph<'a> {
             .flatten()
     }
 
-    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    pub fn replace_text<'b, I, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
     where
         S: AsRef<str> + 'b,
-        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+        T: IntoIterator<Item = I> + Copy,
+        I: Borrow<(S, S)>,
     {
         for content in self.content.iter_mut() {
             match content {

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -1,7 +1,7 @@
 #![allow(unused_must_use)]
 use derive_more::From;
 use hard_xml::{XmlRead, XmlWrite};
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 
 use crate::{
     __setter, __xml_test_suites,
@@ -151,22 +151,21 @@ impl<'a> Run<'a> {
     where
         S: AsRef<str>,
     {
-        let dic = (old, new);
-        let dic = vec![dic];
-        self.replace_text(&dic);
+        self.replace_text(&[(old, new)]);
     }
 
-    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> DocxResult<()>
+    pub fn replace_text<'b, I, T, S>(&mut self, dic: T) -> DocxResult<()>
     where
         S: AsRef<str> + 'b,
-        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+        T: IntoIterator<Item = I> + Copy,
+        I: Borrow<(S, S)>,
     {
         for c in self.content.iter_mut() {
             match c {
                 RunContent::Text(t) => {
                     let mut tc = t.text.to_string();
                     for p in dic {
-                        tc = tc.replace(p.0.as_ref(), p.1.as_ref());
+                        tc = tc.replace(p.borrow().0.as_ref(), p.borrow().1.as_ref());
                     }
                     t.text = tc.into();
                 }

--- a/src/document/table.rs
+++ b/src/document/table.rs
@@ -1,6 +1,6 @@
 #![allow(unused_must_use)]
 use hard_xml::{XmlRead, XmlWrite};
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 
 use crate::{
     __setter, __xml_test_suites,
@@ -48,10 +48,11 @@ impl<'a> Table<'a> {
             .flat_map(|content| content.iter_text_mut())
     }
 
-    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    pub fn replace_text<'b, I, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
     where
         S: AsRef<str> + 'b,
-        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+        T: IntoIterator<Item = I> + Copy,
+        I: Borrow<(S, S)>,
     {
         for row in self.rows.iter_mut() {
             row.replace_text(dic)?;

--- a/src/document/table_cell.rs
+++ b/src/document/table_cell.rs
@@ -1,5 +1,5 @@
 #![allow(unused_must_use)]
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 
 use derive_more::From;
 use hard_xml::{XmlRead, XmlWrite};
@@ -55,10 +55,11 @@ impl<'a> TableCell<'a> {
             .flatten()
     }
 
-    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    pub fn replace_text<'b, I, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
     where
         S: AsRef<str> + 'b,
-        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+        T: IntoIterator<Item = I> + Copy,
+        I: Borrow<(S, S)>,
     {
         for content in self.content.iter_mut() {
             match content {

--- a/src/document/table_row.rs
+++ b/src/document/table_row.rs
@@ -1,5 +1,5 @@
 #![allow(unused_must_use)]
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 
 use super::SDT;
 
@@ -83,10 +83,11 @@ impl<'a> TableRow<'a> {
             .flatten()
     }
 
-    pub fn replace_text<'b, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
+    pub fn replace_text<'b, I, T, S>(&mut self, dic: T) -> crate::DocxResult<()>
     where
         S: AsRef<str> + 'b,
-        T: IntoIterator<Item = &'b (S, S)> + std::marker::Copy,
+        T: IntoIterator<Item = I> + Copy,
+        I: Borrow<(S, S)>,
     {
         for cell in self.cells.iter_mut() {
             if let TableRowContent::TableCell(c) = cell {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,11 +1,12 @@
 extern crate docx_rust;
-use std::fs::read_dir;
 
 use docx_rust::{
     document::{BodyContent, ParagraphContent, RunContent},
     rels::TargetMode,
     DocxFile,
 };
+use std::collections::HashMap;
+use std::fs::read_dir;
 
 #[test]
 fn read_and_replace() {
@@ -17,6 +18,32 @@ fn read_and_replace() {
 
     let path2 = std::path::Path::new("./tests/bbb/aa.docx");
     let _d = docx.write_file(path2).unwrap();
+}
+
+#[test]
+fn replace_text_multiple() {
+    // reader
+    let path = std::path::Path::new("./tests/aaa/aa.docx");
+    let book = DocxFile::from_file(path).unwrap();
+    let mut docx = book.parse().unwrap();
+
+    let map = HashMap::from([("好日子", "好天气")]);
+    docx.document.body.replace_text(&map).unwrap();
+
+    let map = HashMap::from([("好日子".to_string(), "好天气".to_string())]);
+    docx.document.body.replace_text(&map).unwrap();
+
+    let slice = [("好日子", "好天气")];
+    docx.document.body.replace_text(&slice).unwrap();
+
+    let slice = [("好日子".to_string(), "好天气".to_string())];
+    docx.document.body.replace_text(&slice).unwrap();
+
+    let vec = vec![("好日子", "好天气")];
+    docx.document.body.replace_text(&vec).unwrap();
+
+    let vec = vec![("好日子".to_string(), "好天气".to_string())];
+    docx.document.body.replace_text(&vec).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This allows borrowed iterators (like Hashmap's, slices or vec's) as input for `replace_text`.