### PR TITLE
fix NoteSeparator type in foot/end notes

### DIFF
--- a/src/document/endnotes.rs
+++ b/src/document/endnotes.rs
@@ -26,7 +26,7 @@ pub struct EndNotes<'a> {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:endnote")]
 pub struct EndNote<'a> {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:type")]
     pub ty: Option<NoteSeparator>,
     #[xml(attr = "w:id")]
     pub id: Option<isize>,

--- a/src/document/footnotes.rs
+++ b/src/document/footnotes.rs
@@ -24,7 +24,7 @@ pub struct FootNotes<'a> {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:footnote")]
 pub struct FootNote<'a> {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:type")]
     pub ty: Option<NoteSeparator>,
     #[xml(attr = "w:id")]
     pub id: Option<isize>,
@@ -87,12 +87,14 @@ impl<'a> XmlWrite for FootNotes<'a> {
 pub enum NoteSeparator {
     Separator,
     ContinuationSeparator,
+    ContinuationNotice,
 }
 
 __string_enum! {
     NoteSeparator {
         Separator = "separator",
         ContinuationSeparator = "continuationSeparator",
+        ContinuationNotice = "continuationNotice",
     }
 }
 


### PR DESCRIPTION
The type property of `EndNote` and `FootNote` has a wrong attribute name. This error caused validation errors when opening a file generated by docx-rs with Word. 