### PR TITLE
Add Relations schema to settings.xml

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -7,7 +7,7 @@ use hard_xml::{XmlRead, XmlResult, XmlWrite, XmlWriter};
 use std::borrow::Cow;
 use std::io::Write;
 
-use crate::schema::{SCHEMA_MAIN, SCHEMA_WORDML_14};
+use crate::schema::{SCHEMA_MAIN, SCHEMA_RELATIONSHIPS_DOCUMENT, SCHEMA_WORDML_14};
 use crate::{__string_enum, __xml_test_suites, write_attr};
 
 /// The root element of the main document part.
@@ -1241,6 +1241,8 @@ impl<'a> XmlWrite for Settings<'a> {
 
         writer.write_element_start("w:settings")?;
 
+        writer.write_attribute("xmlns:r", SCHEMA_RELATIONSHIPS_DOCUMENT)?;
+
         writer.write_attribute("xmlns:w", SCHEMA_MAIN)?;
 
         writer.write_attribute("xmlns:w14", SCHEMA_WORDML_14)?;
@@ -1355,8 +1357,9 @@ __xml_test_suites!(
     Settings,
     Settings::default(),
     format!(
-        r#"{}<w:settings xmlns:w="{}" xmlns:w14="{}"></w:settings>"#,
+        r#"{}<w:settings xmlns:r="{}" xmlns:w="{}" xmlns:w14="{}"></w:settings>"#,
         crate::schema::SCHEMA_XML,
+        SCHEMA_RELATIONSHIPS_DOCUMENT,
         SCHEMA_MAIN,
         SCHEMA_WORDML_14
     )


### PR DESCRIPTION
`settings.xml` was missing the `r` schema. Because settings contains the following entry it requires this schema. This was causing validation errors in MS Word.
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<w:settings>
    <w:attachedTemplate r:id="rId1"/>
</w:settings>
```