### PR TITLE
Make nsid field optional

### DIFF
--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -307,7 +307,7 @@ fn xml_parsing() {
     let numbering = Numbering::from_str(NUMBERING_XML).unwrap();
     assert_eq!(numbering.abstract_numberings.len(), 2);
     assert_eq!(numbering.numberings.len(), 2);
-    assert_eq!(numbering.abstract_numberings[0].nsid.value, "0000A990");
+    assert_eq!(numbering.abstract_numberings[0].nsid.unwrap().value, "0000A990");
     assert_eq!(
         numbering.abstract_numberings[0].levels[0]
             .number_format

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -32,7 +32,7 @@ pub struct AbstractNum<'a> {
     #[xml(attr = "w:abstractNumId")]
     pub abstract_num_id: Option<isize>,
     #[xml(child = "w:nsid")]
-    pub nsid: Nsid<'a>,
+    pub nsid: Option<Nsid<'a>>,
     #[xml(child = "w:multiLevelType")]
     pub multi_level_type: MultiLevelType<'a>,
     #[xml(child = "w:lvl")]

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -307,7 +307,10 @@ fn xml_parsing() {
     let numbering = Numbering::from_str(NUMBERING_XML).unwrap();
     assert_eq!(numbering.abstract_numberings.len(), 2);
     assert_eq!(numbering.numberings.len(), 2);
-    assert_eq!(numbering.abstract_numberings[0].nsid.unwrap().value, "0000A990");
+    assert_eq!(
+        numbering.abstract_numberings[0].nsid.unwrap().value,
+        "0000A990"
+    );
     assert_eq!(
         numbering.abstract_numberings[0].levels[0]
             .number_format

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -308,7 +308,11 @@ fn xml_parsing() {
     assert_eq!(numbering.abstract_numberings.len(), 2);
     assert_eq!(numbering.numberings.len(), 2);
     assert_eq!(
-        numbering.abstract_numberings[0].nsid.as_ref().unwrap().value,
+        numbering.abstract_numberings[0]
+            .nsid
+            .as_ref()
+            .unwrap()
+            .value,
         "0000A990"
     );
     assert_eq!(

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -308,7 +308,7 @@ fn xml_parsing() {
     assert_eq!(numbering.abstract_numberings.len(), 2);
     assert_eq!(numbering.numberings.len(), 2);
     assert_eq!(
-        numbering.abstract_numberings[0].nsid.unwrap().value,
+        numbering.abstract_numberings[0].nsid.as_ref().unwrap().value,
         "0000A990"
     );
     assert_eq!(


### PR DESCRIPTION
The `nsid` field of `AbstractNum` is not required according to the Microsoft documentation (see [here](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.nsid?view=openxml-3.0.1)). It says that: 
```If this element is omitted, then the list shall have no nsid and one can be added by a producer arbitrarily.```

Currently, docx-rs requires this field and errors if it is not present. This is overly restrictive. Some applications produce docx files without this field and cannot be opened.