### PR TITLE
Update zip crate to v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,13 @@ readme = "README.md"
 repository = "https://github.com/cstkingkey/docx-rs"
 description = "A Rust library for parsing and generating docx files."
 keywords = ["docx", "generator", "openxml", "parser"]
+rust-version = "1.75.0"
 
 [dependencies]
 derive_more = "0.99.17"
 log = "0.4.14"
 hard-xml = "1.27.0"
-zip = {version = "1.1.2", default-features = false, features = ["deflate"]}
+zip = {version = "4", default-features = false, features = ["deflate"]}
 thiserror = "1"
 async_zip = { version = "0.0.17", default-features = false, features = ["deflate"], optional = true }
 futures-io = { version = "0.3.31" , optional = true}


### PR DESCRIPTION
Version 4 has many bug fixes, and some useful capabilities such as selecting different flate2 backends.

This increases the MSRV to 1.75 so I added that info to the `Cargo.toml` to help users who are on earlier versions of Rust.