### PR TITLE
added support for floating point values in field that should not be floating points

### DIFF
--- a/src/document/drawing.rs
+++ b/src/document/drawing.rs
@@ -22,17 +22,17 @@ pub struct Drawing<'a> {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "wp:anchor")]
 pub struct Anchor<'a> {
-    #[xml(attr = "distT")]
+    #[xml(attr = "distT", with = "crate::rounded_float")]
     pub dist_t: Option<isize>,
-    #[xml(attr = "distB")]
+    #[xml(attr = "distB", with = "crate::rounded_float")]
     pub dist_b: Option<isize>,
-    #[xml(attr = "distL")]
+    #[xml(attr = "distL", with = "crate::rounded_float")]
     pub dist_l: Option<isize>,
-    #[xml(attr = "distR")]
+    #[xml(attr = "distR", with = "crate::rounded_float")]
     pub dist_r: Option<isize>,
-    #[xml(attr = "simplePos")]
+    #[xml(attr = "simplePos", with = "crate::rounded_float")]
     pub simple_pos_attr: Option<isize>,
-    #[xml(attr = "relativeHeight")]
+    #[xml(attr = "relativeHeight", with = "crate::rounded_float")]
     pub relative_height: Option<isize>,
     #[xml(attr = "behindDoc")]
     pub behind_doc: Option<bool>,
@@ -116,9 +116,9 @@ pub struct WrapPolygon {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "wp:start")]
 pub struct WrapPolygonStart {
-    #[xml(attr = "x")]
+    #[xml(attr = "x", with = "crate::rounded_float")]
     pub x: Option<isize>,
-    #[xml(attr = "y")]
+    #[xml(attr = "y", with = "crate::rounded_float")]
     pub y: Option<isize>,
 }
 
@@ -126,9 +126,9 @@ pub struct WrapPolygonStart {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "wp:lineTo")]
 pub struct WrapPolygonLineTo {
-    #[xml(attr = "x")]
+    #[xml(attr = "x", with = "crate::rounded_float")]
     pub x: Option<isize>,
-    #[xml(attr = "y")]
+    #[xml(attr = "y", with = "crate::rounded_float")]
     pub y: Option<isize>,
 }
 
@@ -160,7 +160,7 @@ pub struct WrapTopAndBottom {}
 pub struct PositionHorizontal {
     #[xml(attr = "relativeFrom")]
     pub relative_from: Option<RelativeFromH>,
-    #[xml(flatten_text = "wp:posOffset")]
+    #[xml(flatten_text = "wp:posOffset", with = "crate::rounded_float")]
     pub pos_offset: Option<isize>,
 }
 
@@ -170,7 +170,7 @@ pub struct PositionHorizontal {
 pub struct PositionVertical {
     #[xml(attr = "relativeFrom")]
     pub relative_from: Option<RelativeFromV>,
-    #[xml(flatten_text = "wp:posOffset")]
+    #[xml(flatten_text = "wp:posOffset", with = "crate::rounded_float")]
     pub pos_offset: Option<isize>,
 }
 
@@ -204,17 +204,17 @@ __define_enum! {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "wp:inline")]
 pub struct Inline<'a> {
-    #[xml(attr = "distT")]
+    #[xml(attr = "distT", with = "crate::rounded_float")]
     pub dist_t: Option<isize>,
-    #[xml(attr = "distB")]
+    #[xml(attr = "distB", with = "crate::rounded_float")]
     pub dist_b: Option<isize>,
-    #[xml(attr = "distL")]
+    #[xml(attr = "distL", with = "crate::rounded_float")]
     pub dist_l: Option<isize>,
-    #[xml(attr = "distR")]
+    #[xml(attr = "distR", with = "crate::rounded_float")]
     pub dist_r: Option<isize>,
-    #[xml(attr = "simplePossimplePos")]
+    #[xml(attr = "simplePossimplePos", with = "crate::rounded_float")]
     pub simple_pos_attr: Option<isize>,
-    #[xml(attr = "relativeHeight")]
+    #[xml(attr = "relativeHeight", with = "crate::rounded_float")]
     pub relative_height: Option<isize>,
     #[xml(attr = "behindDoc")]
     pub behind_doc: Option<bool>,
@@ -243,7 +243,7 @@ pub struct Inline<'a> {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "wp:docPr")]
 pub struct DocPr<'a> {
-    #[xml(attr = "id")]
+    #[xml(attr = "id", with = "crate::rounded_float")]
     pub id: Option<isize>,
     #[xml(attr = "name")]
     pub name: Option<Cow<'a, str>>,
@@ -325,9 +325,9 @@ pub struct Xfrm {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:ext")]
 pub struct Ext {
-    #[xml(attr = "cx")]
+    #[xml(attr = "cx", with = "crate::rounded_float")]
     pub cx: Option<isize>,
-    #[xml(attr = "cy")]
+    #[xml(attr = "cy", with = "crate::rounded_float")]
     pub cy: Option<isize>,
 }
 
@@ -335,9 +335,9 @@ pub struct Ext {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:off")]
 pub struct Offset {
-    #[xml(attr = "x")]
+    #[xml(attr = "x", with = "crate::rounded_float")]
     pub x: Option<isize>,
-    #[xml(attr = "y")]
+    #[xml(attr = "y", with = "crate::rounded_float")]
     pub y: Option<isize>,
 }
 
@@ -345,9 +345,9 @@ pub struct Offset {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "wp:simplePos")]
 pub struct SimplePos {
-    #[xml(attr = "x")]
+    #[xml(attr = "x", with = "crate::rounded_float")]
     pub x: Option<isize>,
-    #[xml(attr = "y")]
+    #[xml(attr = "y", with = "crate::rounded_float")]
     pub y: Option<isize>,
 }
 
@@ -365,7 +365,7 @@ pub struct NvPicPr<'a> {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "pic:cNvPr")]
 pub struct CNvPr<'a> {
-    #[xml(attr = "id")]
+    #[xml(attr = "id", with = "crate::rounded_float")]
     pub id: Option<isize>,
     #[xml(attr = "name")]
     pub name: Option<Cow<'a, str>>,

--- a/src/document/endnotes.rs
+++ b/src/document/endnotes.rs
@@ -28,7 +28,7 @@ pub struct EndNotes<'a> {
 pub struct EndNote<'a> {
     #[xml(attr = "w:type")]
     pub ty: Option<NoteSeparator>,
-    #[xml(attr = "w:id")]
+    #[xml(attr = "w:id", with = "crate::rounded_float")]
     pub id: Option<isize>,
     #[xml(child = "w:sdt", child = "w:p", child = "w:tbl", child = "w:sectPr")]
     pub content: Vec<BodyContent<'a>>,

--- a/src/document/footnotes.rs
+++ b/src/document/footnotes.rs
@@ -26,7 +26,7 @@ pub struct FootNotes<'a> {
 pub struct FootNote<'a> {
     #[xml(attr = "w:type")]
     pub ty: Option<NoteSeparator>,
-    #[xml(attr = "w:id")]
+    #[xml(attr = "w:id", with = "crate::rounded_float")]
     pub id: Option<isize>,
     #[xml(child = "w:sdt", child = "w:p", child = "w:tbl", child = "w:sectPr")]
     pub content: Vec<BodyContent<'a>>,

--- a/src/document/grid_column.rs
+++ b/src/document/grid_column.rs
@@ -13,7 +13,7 @@ use crate::__xml_test_suites;
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:gridCol")]
 pub struct GridColumn {
-    #[xml(attr = "w:w")]
+    #[xml(attr = "w:w", with = "crate::rounded_float")]
     pub width: isize,
 }
 

--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -143,7 +143,7 @@ pub struct LevelOverride {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:startOverride")]
 pub struct StartOverride {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub value: Option<isize>,
 }
 
@@ -151,7 +151,7 @@ pub struct StartOverride {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:abstractNumId")]
 pub struct AbstractNumId {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub value: Option<isize>,
 }
 

--- a/src/document/sdt.rs
+++ b/src/document/sdt.rs
@@ -70,7 +70,7 @@ pub struct SDTProperty<'a> {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:id")]
 pub struct STDId {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub id: Option<isize>,
 }
 

--- a/src/document/theme.rs
+++ b/src/document/theme.rs
@@ -329,11 +329,11 @@ pub struct Alpha {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:hslClr")]
 pub struct HslClr {
-    #[xml(attr = "hue")]
+    #[xml(attr = "hue", with = "crate::rounded_float")]
     pub hue: Option<isize>,
-    #[xml(attr = "sat")]
+    #[xml(attr = "sat", with = "crate::rounded_float")]
     pub sat: Option<isize>,
-    #[xml(attr = "lum")]
+    #[xml(attr = "lum", with = "crate::rounded_float")]
     pub lum: Option<isize>,
 }
 
@@ -438,7 +438,7 @@ pub struct SchemeClr {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:lumMod")]
 pub struct LuminanceModulation {
-    #[xml(attr = "val")]
+    #[xml(attr = "val", with = "crate::rounded_float")]
     pub val: isize,
 }
 
@@ -446,7 +446,7 @@ pub struct LuminanceModulation {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:satMod")]
 pub struct SaturationModulation {
-    #[xml(attr = "val")]
+    #[xml(attr = "val", with = "crate::rounded_float")]
     pub val: isize,
 }
 
@@ -454,7 +454,7 @@ pub struct SaturationModulation {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:tint")]
 pub struct Tint {
-    #[xml(attr = "val")]
+    #[xml(attr = "val", with = "crate::rounded_float")]
     pub val: isize,
 }
 
@@ -462,7 +462,7 @@ pub struct Tint {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:shade")]
 pub struct Shade {
-    #[xml(attr = "val")]
+    #[xml(attr = "val", with = "crate::rounded_float")]
     pub val: isize,
 }
 
@@ -1042,7 +1042,7 @@ pub struct GradientStopList {
 
 __define_struct_vec! {
     ("a:gs", GradientStop, GradientStopChoice) {
-        "pos", position, isize
+        "pos", position, isize, "crate::rounded_float"
     } {
         "a:scrgbClr", ScrgbClr
         "a:srgbClr", SrgbClr
@@ -1057,7 +1057,7 @@ __define_struct_vec! {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:lin")]
 pub struct LinearGradientFill {
-    #[xml(attr = "ang")]
+    #[xml(attr = "ang", with = "crate::rounded_float")]
     pub angle: isize,
     #[xml(attr = "scaled")]
     pub scaled: bool,
@@ -1073,7 +1073,7 @@ pub struct LineStyleList {
 
 __define_struct_vec! {
     ("a:ln", Outline, OutlineChoice) {
-        "w", line_with, isize
+        "w", line_with, isize, "crate::rounded_float"
         "cap", cap, CapType
         "cmpd", cmpd, CompoundLineType
         "algn", algn, PenAlignment
@@ -1127,7 +1127,7 @@ __string_enum! {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "a:miter")]
 pub struct MiterLineJoin {
-    #[xml(attr = "lim")]
+    #[xml(attr = "lim", with = "crate::rounded_float")]
     pub limit: isize,
 }
 
@@ -1220,9 +1220,9 @@ pub struct OuterShadow {
     pub direction: Option<isize>,
     #[xml(attr = "algn")]
     pub alignment: Option<PenAlignment>,
-    #[xml(attr = "kx")]
+    #[xml(attr = "kx", with = "crate::rounded_float")]
     pub kx: Option<isize>,
-    #[xml(attr = "ky")]
+    #[xml(attr = "ky", with = "crate::rounded_float")]
     pub ky: Option<isize>,
     #[xml(attr = "rotWithShape")]
     pub rotate_with_shape: Option<bool>,

--- a/src/formatting/indent_level.rs
+++ b/src/formatting/indent_level.rs
@@ -13,7 +13,7 @@ use crate::__xml_test_suites;
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:ilvl")]
 pub struct IndentLevel {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub value: isize,
 }
 

--- a/src/formatting/numbering_id.rs
+++ b/src/formatting/numbering_id.rs
@@ -13,7 +13,7 @@ use crate::__xml_test_suites;
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:numId")]
 pub struct NumberingId {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub value: isize,
 }
 

--- a/src/formatting/page_size.rs
+++ b/src/formatting/page_size.rs
@@ -11,9 +11,9 @@ use hard_xml::{XmlRead, XmlWrite};
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:pgSz")]
 pub struct PageSize {
-    #[xml(attr = "w:w")]
+    #[xml(attr = "w:w", with = "crate::rounded_float")]
     pub weight: isize,
-    #[xml(attr = "w:h")]
+    #[xml(attr = "w:h", with = "crate::rounded_float")]
     pub height: isize,
 }
 

--- a/src/formatting/paragraph_property.rs
+++ b/src/formatting/paragraph_property.rs
@@ -291,7 +291,7 @@ pub struct SuppressOverlap {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:outlineLvl")]
 pub struct OutlineLvl {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub value: isize,
 }
 
@@ -299,7 +299,7 @@ pub struct OutlineLvl {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:divId")]
 pub struct DivId {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub value: isize,
 }
 
@@ -315,7 +315,7 @@ pub struct CnfStyle<'a> {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:pPrChange")]
 pub struct RevisionParagraphProperty<'a> {
-    #[xml(attr = "w:id")]
+    #[xml(attr = "w:id", with = "crate::rounded_float")]
     pub id: isize,
     #[xml(attr = "w:author")]
     pub author: Cow<'a, str>,
@@ -459,7 +459,7 @@ __define_struct! {
     ("w:tab", CustomTabStop) {
         "w:val", tab_stop_type, TabStopType
         "w:leader", leader, TabLeaderCharacter
-        "w:pos", pos, isize
+        "w:pos", pos, isize, "crate::rounded_float"
     }
 }
 

--- a/src/formatting/section_property.rs
+++ b/src/formatting/section_property.rs
@@ -202,8 +202,8 @@ __define_struct! {
         "w:themeColor", theme_color, crate::formatting::ThemeColor
         "w:themeTint", theme_tint, String
         "w:themeShade", theme_shade, String
-        "w:sz", size, isize // Measurement in Eighths of a Point
-        "w:space", space, isize
+        "w:sz", size, isize, "crate::rounded_float" // Measurement in Eighths of a Point
+        "w:space", space, isize, "crate::rounded_float"
         "w:shadow", shadow, bool
         "w:frame", frame, bool
     }
@@ -216,8 +216,8 @@ __define_struct! {
         "w:themeColor", theme_color, crate::formatting::ThemeColor
         "w:themeTint", theme_tint, String
         "w:themeShade", theme_shade, String
-        "w:sz", size, isize // Measurement in Eighths of a Point
-        "w:space", space, isize
+        "w:sz", size, isize, "crate::rounded_float" // Measurement in Eighths of a Point
+        "w:space", space, isize, "crate::rounded_float"
         "w:shadow", shadow, bool
         "w:frame", frame, bool
     }
@@ -230,8 +230,8 @@ __define_struct! {
         "w:themeColor", theme_color, crate::formatting::ThemeColor
         "w:themeTint", theme_tint, String
         "w:themeShade", theme_shade, String
-        "w:sz", size, isize // Measurement in Eighths of a Point
-        "w:space", space, isize
+        "w:sz", size, isize, "crate::rounded_float"// Measurement in Eighths of a Point
+        "w:space", space, isize, "crate::rounded_float"
         "w:shadow", shadow, bool
         "w:frame", frame, bool
     }
@@ -244,8 +244,8 @@ __define_struct! {
         "w:themeColor", theme_color, crate::formatting::ThemeColor
         "w:themeTint", theme_tint, String
         "w:themeShade", theme_shade, String
-        "w:sz", size, isize // Measurement in Eighths of a Point
-        "w:space", space, isize
+        "w:sz", size, isize, "crate::rounded_float" // Measurement in Eighths of a Point
+        "w:space", space, isize, "crate::rounded_float"
         "w:shadow", shadow, bool
         "w:frame", frame, bool
     }
@@ -253,9 +253,9 @@ __define_struct! {
 
 __define_struct! {
     ("w:lnNumType", PgLnNumType) {
-        "w:countBy", count_by, isize //	[0..1]	w:ST_DecimalNumber	Line Number Increments to Display
-        "w:start", start, isize //	[0..1]	w:ST_DecimalNumber	Line Numbering Starting Value
-        "w:distance", distance, isize //	[0..1]	w:ST_TwipsMeasure	Distance Between Text and Line Numbering
+        "w:countBy", count_by, isize, "crate::rounded_float" //	[0..1]	w:ST_DecimalNumber	Line Number Increments to Display
+        "w:start", start, isize, "crate::rounded_float" //	[0..1]	w:ST_DecimalNumber	Line Numbering Starting Value
+        "w:distance", distance, isize, "crate::rounded_float" //	[0..1]	w:ST_TwipsMeasure	Distance Between Text and Line Numbering
         "w:restart", restart, LineNumberRestart //	[0..1]	w:ST_LineNumberRestart	Line Numbering Restart Setting
     }
 }
@@ -272,8 +272,8 @@ __define_enum! {
 __define_struct! {
     ("w:pgNumType", PgNumType) {
         "w:fmt", fmt, NumberFormat	//Page Number Format
-        "w:start", start, isize //	[0..1]	w:ST_DecimalNumber	Starting Page Number
-        "w:chapStyle", chap_style, isize//	[0..1]	w:ST_DecimalNumber	Chapter Heading Style
+        "w:start", start, isize, "crate::rounded_float" //	[0..1]	w:ST_DecimalNumber	Starting Page Number
+        "w:chapStyle", chap_style, isize, "crate::rounded_float"//	[0..1]	w:ST_DecimalNumber	Chapter Heading Style
         "w:chapSep", chap_sep, ChapterSep//	Chapter Separator Character
     }
 }
@@ -357,7 +357,7 @@ __define_enum! {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:sectPrChange")]
 pub struct Revision<'a> {
-    #[xml(attr = "w:id")]
+    #[xml(attr = "w:id", with = "crate::rounded_float")]
     pub id: isize,
     #[xml(attr = "w:author")]
     pub author: Cow<'a, str>,
@@ -593,7 +593,7 @@ pub struct FootnoteProperty2 {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:footnote")]
 pub struct Footnote {
-    #[xml(attr = "w:id")]
+    #[xml(attr = "w:id", with = "crate::rounded_float")]
     pub id: isize,
 }
 
@@ -619,7 +619,7 @@ pub struct EndnoteProperty2 {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:endnote")]
 pub struct Endnote {
-    #[xml(attr = "w:id")]
+    #[xml(attr = "w:id", with = "crate::rounded_float")]
     pub id: isize,
 }
 

--- a/src/formatting/size.rs
+++ b/src/formatting/size.rs
@@ -13,7 +13,7 @@ use crate::__xml_test_suites;
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:sz")]
 pub struct Size {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub value: isize,
 }
 

--- a/src/formatting/spacing.rs
+++ b/src/formatting/spacing.rs
@@ -34,7 +34,7 @@ pub struct Spacing {
     pub after: Option<isize>,
     #[xml(attr = "w:afterAutospacing")]
     pub after_auto_spacing: Option<bool>,
-    #[xml(attr = "w:line")]
+    #[xml(attr = "w:line", with = "crate::rounded_float")]
     pub line: Option<isize>,
     #[xml(attr = "w:lineRule")]
     pub line_rule: Option<LineRule>,

--- a/src/formatting/table_width.rs
+++ b/src/formatting/table_width.rs
@@ -15,7 +15,7 @@ use crate::{__string_enum, __xml_test_suites};
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:tblW")]
 pub struct TableWidth {
-    #[xml(attr = "w:w")]
+    #[xml(attr = "w:w", with = "crate::rounded_float")]
     pub value: Option<isize>,
     #[xml(attr = "w:type")]
     pub unit: Option<TableWidthUnit>,
@@ -25,7 +25,7 @@ pub struct TableWidth {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:tcW")]
 pub struct TableCellWidth {
-    #[xml(attr = "w:w")]
+    #[xml(attr = "w:w", with = "crate::rounded_float")]
     pub value: Option<isize>,
     #[xml(attr = "w:type")]
     pub unit: Option<TableWidthUnit>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,12 @@ pub use crate::error::{DocxError, DocxResult};
 pub mod rounded_float {
     use std::num::ParseFloatError;
     pub fn from_xml(mode: &str) -> hard_xml::XmlResult<isize> {
-        let f: f64 = mode.parse()
+        let f: f64 = mode
+            .parse()
             .map_err(|e: ParseFloatError| hard_xml::XmlError::FromStr(e.into()))?;
 
-        let r = f.is_finite()
+        let r = f
+            .is_finite()
             .then_some(f.round())
             .ok_or_else(|| hard_xml::XmlError::FromStr("f64 must be finite".into()))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,23 @@ use hard_xml::{XmlWrite, XmlWriter};
 pub use crate::docx::{Docx, DocxFile};
 pub use crate::error::{DocxError, DocxResult};
 
+pub mod rounded_float {
+    use std::num::ParseFloatError;
+    pub fn from_xml(mode: &str) -> hard_xml::XmlResult<isize> {
+        let f: f64 = mode.parse()
+            .map_err(|e: ParseFloatError| hard_xml::XmlError::FromStr(e.into()))?;
+
+        let r = f.is_finite()
+            .then_some(f.round())
+            .ok_or_else(|| hard_xml::XmlError::FromStr("f64 must be finite".into()))?;
+
+        hard_xml::XmlResult::Ok(r as isize)
+    }
+    pub fn to_xml(mode: &isize) -> hard_xml::XmlResult<String> {
+        Ok(mode.to_string())
+    }
+}
+
 pub fn write_attr<W: Write, T: XmlWrite>(
     element: &Option<T>,
     writer: &mut XmlWriter<W>,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __define_struct_vec {
-    ( ($tag:expr, $name:ident, $choicename:ident) { $($value2:expr, $variant2:ident, $ty2: ty)* } { $($value:expr, $variant:ident)* }) => {
+    ( ($tag:expr, $name:ident, $choicename:ident) { $($value2:expr, $variant2:ident, $ty2: ty $(, $with:literal)?)* } { $($value:expr, $variant:ident)* }) => {
         #[derive(Debug, XmlRead, XmlWrite, Clone)]
         #[cfg_attr(test, derive(PartialEq))]
         pub enum $choicename {
@@ -16,7 +16,7 @@ macro_rules! __define_struct_vec {
         #[xml(tag = $tag)]
         pub struct $name {
             $(
-                #[xml(attr = $value2)]
+                #[xml(attr = $value2 $(, with = $with)?)]
                 pub $variant2: Option<$ty2>,
             )*
 
@@ -64,14 +64,13 @@ macro_rules! __define_struct {
             )*
         }
     };
-
-    ( ($tag:expr, $name:ident) { $($value:expr, $variant:ident, $ty: ty)* }) => {
+    ( ($tag:expr, $name:ident) { $($value:expr, $variant:ident, $ty:ty $(, $with:literal)?)* }) => {
         #[derive(Debug, XmlRead, XmlWrite, Clone, Default)]
         #[cfg_attr(test, derive(PartialEq))]
         #[xml(tag = $tag)]
         pub struct $name {
             $(
-                #[xml(attr = $value)]
+                #[xml(attr = $value $(, with = $with)?)]
                 pub $variant: Option<$ty>,
             )*
         }
@@ -86,7 +85,6 @@ macro_rules! __define_struct {
             )*
         }
     };
-
     ( ($tag:expr, $name:ident) { $($value:expr, $variant:ident, $ty: ty)* } { $($value2:expr, $variant2:ident, $ty2: ty)* }) => {
         #[derive(Debug, XmlRead, XmlWrite, Clone, Default)]
         #[cfg_attr(test, derive(PartialEq))]

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -710,7 +710,7 @@ pub struct StyleLockQfset {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:defaultTabStop")]
 pub struct DefaultTabStop {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub val: isize,
 }
 
@@ -788,7 +788,7 @@ pub struct BookFoldPrintingSheets {}
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:drawingGridHorizontalSpacing")]
 pub struct DrawingGridHorizontalSpacing {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub val: isize,
 }
 
@@ -796,7 +796,7 @@ pub struct DrawingGridHorizontalSpacing {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:drawingGridVerticalSpacing")]
 pub struct DrawingGridVerticalSpacing {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub val: isize,
 }
 
@@ -804,7 +804,7 @@ pub struct DrawingGridVerticalSpacing {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:displayHorizontalDrawingGridEvery")]
 pub struct DisplayHorizontalDrawingGridEvery {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub val: isize,
 }
 
@@ -812,7 +812,7 @@ pub struct DisplayHorizontalDrawingGridEvery {
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:displayVerticalDrawingGridEvery")]
 pub struct DisplayVerticalDrawingGridEvery {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub val: isize,
 }
 

--- a/src/styles/priority.rs
+++ b/src/styles/priority.rs
@@ -12,6 +12,6 @@ use hard_xml::{XmlRead, XmlWrite};
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:uiPriority")]
 pub struct Priority {
-    #[xml(attr = "w:val")]
+    #[xml(attr = "w:val", with = "crate::rounded_float")]
     pub value: Option<isize>,
 }


### PR DESCRIPTION
This is out of spec, but google docs tends to generate pretty funky .docx files, I've had multiple some with bad zip encoding, but also it has a tendency to use floating point numbers in fields that should really be integers.

Today, I ran into a document with its line spacing set to `275.9999942779541`, which made it impossible to parse the rest of it.

It's apparently a pretty longstanding problem, so I decided to add an indirection module that makes it possible to parse an `f64` into an `isize`.
<https://www.docx4java.org/forums/docx-java-f6/problem-with-document-created-by-google-docs-t1802.html>

Depending on how you feel about supporting out-of-spec documents, this code could be reworked to be gated behind a feature.