### PR TITLE
added support for parsing bools out of 0 or 1

### DIFF
--- a/src/formatting/margin/bottom_margin.rs
+++ b/src/formatting/margin/bottom_margin.rs
@@ -8,7 +8,7 @@ use crate::__setter;
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:bottom")]
 pub struct BottomMargin<'a> {
-    #[xml(attr = "w:w")]
+    #[xml(attr = "w:w", with = "crate::rounded_float")]
     pub size: Option<isize>,
     #[xml(attr = "w:type")]
     pub ty: Option<Cow<'a, str>>,

--- a/src/formatting/margin/left_margin.rs
+++ b/src/formatting/margin/left_margin.rs
@@ -8,7 +8,7 @@ use crate::__setter;
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:left")]
 pub struct LeftMargin<'a> {
-    #[xml(attr = "w:w")]
+    #[xml(attr = "w:w", with = "crate::rounded_float")]
     pub size: Option<isize>,
     #[xml(attr = "w:type")]
     pub ty: Option<Cow<'a, str>>,

--- a/src/formatting/margin/right_margin.rs
+++ b/src/formatting/margin/right_margin.rs
@@ -8,7 +8,7 @@ use crate::__setter;
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:right")]
 pub struct RightMargin<'a> {
-    #[xml(attr = "w:w")]
+    #[xml(attr = "w:w", with = "crate::rounded_float")]
     pub size: Option<isize>,
     #[xml(attr = "w:type")]
     pub ty: Option<Cow<'a, str>>,

--- a/src/formatting/margin/top_margin.rs
+++ b/src/formatting/margin/top_margin.rs
@@ -8,7 +8,7 @@ use crate::__setter;
 #[cfg_attr(test, derive(PartialEq))]
 #[xml(tag = "w:top")]
 pub struct TopMargin<'a> {
-    #[xml(attr = "w:w")]
+    #[xml(attr = "w:w", with = "crate::rounded_float")]
     pub size: Option<isize>,
     #[xml(attr = "w:type")]
     pub ty: Option<Cow<'a, str>>,

--- a/src/formatting/table_header.rs
+++ b/src/formatting/table_header.rs
@@ -1,6 +1,6 @@
 use hard_xml::{XmlRead, XmlWrite};
 
-use crate::{__string_enum, __xml_test_suites};
+use crate::__xml_test_suites;
 
 /// Table Justification
 ///
@@ -23,17 +23,39 @@ impl From<OnOffOnlyType> for TableHeader {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(test, derive(PartialEq))]
+#[repr(u8)]
 pub enum OnOffOnlyType {
-    On,
-    Off,
+    Off = 0,
+    On = 1,
 }
 
-__string_enum! {
-    OnOffOnlyType {
-        On = "on",
-        Off = "off",
+impl OnOffOnlyType {
+    const STR_REPR: [&str; 2] = ["off", "on"];
+}
+
+impl std::fmt::Display for OnOffOnlyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", Self::STR_REPR[*self as usize])
+    }
+}
+
+impl std::str::FromStr for OnOffOnlyType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            s if s == Self::STR_REPR[0] => Ok(Self::Off),
+            s if s == Self::STR_REPR[1] => Ok(Self::On),
+            "0" => Ok(Self::Off),
+            "1" => Ok(Self::On),
+            s => Err(format!(
+                "Unkown Value. Found `{}`, Expected `{:?}`",
+                s,
+                Self::STR_REPR
+            )),
+        }
     }
 }
 
@@ -46,3 +68,15 @@ __xml_test_suites!(
     TableHeader::from(OnOffOnlyType::Off),
     r#"<w:tblHeader w:val="off"/>"#,
 );
+
+#[test]
+fn parse_bool_from_int() {
+    use std::str::FromStr;
+
+    for (i, v) in OnOffOnlyType::STR_REPR.iter().enumerate() {
+        assert_eq!(
+            OnOffOnlyType::from_str(&format!("{}", i)).unwrap(),
+            OnOffOnlyType::from_str(v).unwrap(),
+        );
+    }
+}


### PR DESCRIPTION
Google docs generates documents where instead of "on" or "off" on certain properties, it uses 0 or 1

I've also added a few calls to rounded floats I had forgotten in my last patch.