### PR TITLE
fix: parsing of some douments with absent LinearGradientFill and/or LevelText 

### DIFF
--- a/src/document/numbering.rs
+++ b/src/document/numbering.rs
@@ -44,7 +44,7 @@ pub struct AbstractNum<'a> {
 #[xml(tag = "w:nsid")]
 pub struct Nsid<'a> {
     #[xml(attr = "w:val")]
-    pub value: Cow<'a, str>,
+    pub value: Option<Cow<'a, str>>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
@@ -106,7 +106,7 @@ pub struct LevelStart {
 #[xml(tag = "w:lvlText")]
 pub struct LevelText<'a> {
     #[xml(attr = "w:val")]
-    pub value: Cow<'a, str>,
+    pub value: Option<Cow<'a, str>>,
 }
 
 #[derive(Debug, XmlRead, XmlWrite, Clone)]
@@ -312,7 +312,10 @@ fn xml_parsing() {
             .nsid
             .as_ref()
             .unwrap()
-            .value,
+            .value
+            .as_ref()
+            .unwrap()
+            .as_ref(),
         "0000A990"
     );
     assert_eq!(
@@ -361,7 +364,7 @@ fn find_numbering_details() {
         assert_eq!(
             num.levels[1].level_text,
             Some(LevelText {
-                value: Cow::Borrowed("%2.")
+                value: Some(Cow::Borrowed("%2."))
             })
         );
     }

--- a/src/document/theme.rs
+++ b/src/document/theme.rs
@@ -1058,9 +1058,9 @@ __define_struct_vec! {
 #[xml(tag = "a:lin")]
 pub struct LinearGradientFill {
     #[xml(attr = "ang", with = "crate::rounded_float")]
-    pub angle: isize,
+    pub angle: Option<isize>,
     #[xml(attr = "scaled")]
-    pub scaled: bool,
+    pub scaled: Option<bool>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]


### PR DESCRIPTION
1. LinearGradientFill (src/document/theme.rs): Made angle and scaled fields optional (they were incorrectly required)
2. LevelText (src/document/numbering.rs): Made the value field optional (it was incorrectly required)