### PR TITLE
feat(header-footer): add Docx::add_header/add_footer + page-field helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures-io = { version = "0.3.31" , optional = true}
 
 [dev-dependencies]
 env_logger = "0.11.3"
+png = "0.17"
 tokio = { version = "1.43.0" , features = ["macros", "rt", "fs", "io-util"]}
 tokio-util = { version = "0.7.13", features = ["compat"] }
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,32 @@ fork of https://github.com/PoiScript/docx-rs
 
 [Document](https://docs.rs/docx-rust)
 
+## Embedding inline images
+
+```rust
+use docx_rust::{Docx, document::{Paragraph, Run}, media::{MediaType, Pic}};
+use std::fs;
+
+let png = fs::read("logo.png").unwrap();
+
+let mut docx = Docx::default();
+let rid = docx.add_image("logo.png", MediaType::Image, &png);
+let drawing = Pic::new(rid).size_px(120, 60).into_drawing();
+
+let para = Paragraph::default()
+    .push(Run::default().push_image(drawing));
+docx.document.push(para);
+
+docx.write_file("with-logo.docx").unwrap();
+```
+
+`Docx::add_image` registers the bytes, allocates a relationship id,
+and auto-adds the matching `<Default>` Content Types entry (PNG, JPEG,
+BMP, GIF, TIFF). `Pic` produces the `wp:inline` drawing chain. Use
+`size_px` for 96-DPI pixel sizing or `size_emu` for direct EMU.
+
+See [`examples/image.rs`](./examples/image.rs) for an end-to-end run.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -36,6 +36,51 @@ BMP, GIF, TIFF). `Pic` produces the `wp:inline` drawing chain. Use
 
 See [`examples/image.rs`](./examples/image.rs) for an end-to-end run.
 
+## Headers, footers, and page-number fields
+
+```rust
+use docx_rust::{
+    document::{num_pages_field, page_field, Footer, Header, Paragraph, Run},
+    Docx,
+};
+
+let mut docx = Docx::default();
+
+let mut header = Header::default();
+header.push(Paragraph::default().push(Run::default().push_text("Confidential")));
+docx.add_header(header);
+
+let mut footer = Footer::default();
+footer.push(
+    Paragraph::default()
+        .push(Run::default().push_text("Workbench Export"))
+        .push(Run::default().push_tab())
+        .push(Run::default().push_text("Page "))
+        .push(page_field())
+        .push(Run::default().push_text(" of "))
+        .push(num_pages_field()),
+);
+docx.add_footer(footer);
+
+docx.write_file("with-header-and-footer.docx").unwrap();
+```
+
+`Docx::add_header` / `Docx::add_footer` allocate the next `headerN.xml` /
+`footerN.xml` slot, register the relationship, add the matching
+`<Override>` Content Types entry, and attach a `<w:headerReference>` /
+`<w:footerReference>` to the trailing `<w:sectPr>` (creating one if
+absent). The `_with_type` variants take a
+`HeaderFooterReferenceType::{Default, Even, First}` for first-page-only
+or even-page variants.
+
+`page_field()` and `num_pages_field()` return runs containing the
+`{ PAGE }` and `{ NUMPAGES }` field codes respectively. Word
+substitutes the live values at render time. `field_run(instr)` is the
+escape hatch for arbitrary field instructions.
+
+See [`examples/header_footer.rs`](./examples/header_footer.rs) for an
+end-to-end run.
+
 ## License
 
 MIT

--- a/examples/header_footer.rs
+++ b/examples/header_footer.rs
@@ -1,0 +1,52 @@
+//! Build a document with a header AND a footer that includes the
+//! `Page X of Y` field codes.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example header_footer
+//! ```
+//!
+//! Open `header_footer.docx` in Word. The header should read
+//! "Confidential — Workbench Export" on every page; the footer
+//! should show the doc title on the left and "Page <n> of <total>"
+//! on the right.
+
+use docx_rust::{
+    document::{
+        num_pages_field, page_field, Footer, Header, Paragraph, Run,
+    },
+    Docx, DocxResult,
+};
+
+fn main() -> DocxResult<()> {
+    let mut docx = Docx::default();
+
+    for i in 1..=40 {
+        let para = Paragraph::default()
+            .push(Run::default().push_text(format!("Body paragraph {}.", i)));
+        docx.document.push(para);
+    }
+
+    let mut header = Header::default();
+    header.push(
+        Paragraph::default()
+            .push(Run::default().push_text("Confidential — Workbench Export")),
+    );
+    docx.add_header(header);
+
+    let mut footer = Footer::default();
+    footer.push(
+        Paragraph::default()
+            .push(Run::default().push_text("ImageRight Workbench Export"))
+            .push(Run::default().push_tab())
+            .push(Run::default().push_text("Page "))
+            .push(page_field())
+            .push(Run::default().push_text(" of "))
+            .push(num_pages_field()),
+    );
+    docx.add_footer(footer);
+
+    docx.write_file("header_footer.docx")?;
+    Ok(())
+}

--- a/examples/header_footer.rs
+++ b/examples/header_footer.rs
@@ -9,8 +9,8 @@
 //!
 //! Open `header_footer.docx` in Word. The header should read
 //! "Confidential — Workbench Export" on every page; the footer
-//! should show the doc title on the left and "Page <n> of <total>"
-//! on the right.
+//! should show "ImageRight Workbench Export" on the left and
+//! "Page <n> of <total>" on the right.
 
 use docx_rust::{
     document::{num_pages_field, page_field, Footer, Header, Paragraph, Run},

--- a/examples/header_footer.rs
+++ b/examples/header_footer.rs
@@ -13,9 +13,7 @@
 //! on the right.
 
 use docx_rust::{
-    document::{
-        num_pages_field, page_field, Footer, Header, Paragraph, Run,
-    },
+    document::{num_pages_field, page_field, Footer, Header, Paragraph, Run},
     Docx, DocxResult,
 };
 
@@ -23,15 +21,14 @@ fn main() -> DocxResult<()> {
     let mut docx = Docx::default();
 
     for i in 1..=40 {
-        let para = Paragraph::default()
-            .push(Run::default().push_text(format!("Body paragraph {}.", i)));
+        let para =
+            Paragraph::default().push(Run::default().push_text(format!("Body paragraph {}.", i)));
         docx.document.push(para);
     }
 
     let mut header = Header::default();
     header.push(
-        Paragraph::default()
-            .push(Run::default().push_text("Confidential — Workbench Export")),
+        Paragraph::default().push(Run::default().push_text("Confidential — Workbench Export")),
     );
     docx.add_header(header);
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,0 +1,41 @@
+//! Embed an inline PNG into a docx.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example image
+//! ```
+//!
+//! Output: `image.docx` in the working directory. Open in Word and
+//! the picture should appear inline with the surrounding text.
+
+use docx_rust::{
+    document::{Paragraph, Run},
+    media::{MediaType, Pic},
+    Docx, DocxResult,
+};
+
+/// 1x1 transparent PNG, the smallest valid bytes that decode in Word.
+const TINY_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0x0F, 0x04, 0x00,
+    0x00, 0x09, 0xFB, 0x03, 0xFD, 0x8E, 0xB8, 0x8C, 0x7E, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+fn main() -> DocxResult<()> {
+    let png = TINY_PNG.to_vec();
+
+    let mut docx = Docx::default();
+    let rid = docx.add_image("dot.png", MediaType::Image, &png);
+    let drawing = Pic::new(rid).name("dot").size_px(32, 32).into_drawing();
+
+    let para = Paragraph::default()
+        .push(Run::default().push_text("Behold a tiny dot: "))
+        .push(Run::default().push_image(drawing));
+    docx.document.push(para);
+
+    docx.write_file("image.docx")?;
+    Ok(())
+}

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,13 +1,15 @@
-//! Embed an inline PNG into a docx.
+//! Embed a visible inline PNG into a docx.
+//!
+//! Generates a 32x32 solid red square at runtime using the `png`
+//! dev-dependency, embeds it via the new ergonomic API, and writes
+//! `image.docx` in the working directory. Open in Word: a red square
+//! should appear inline with the surrounding text.
 //!
 //! Run with:
 //!
 //! ```sh
 //! cargo run --example image
 //! ```
-//!
-//! Output: `image.docx` in the working directory. Open in Word and
-//! the picture should appear inline with the surrounding text.
 
 use docx_rust::{
     document::{Paragraph, Run},
@@ -15,24 +17,30 @@ use docx_rust::{
     Docx, DocxResult,
 };
 
-/// 1x1 transparent PNG, the smallest valid bytes that decode in Word.
-const TINY_PNG: &[u8] = &[
-    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
-    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
-    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0x0F, 0x04, 0x00,
-    0x00, 0x09, 0xFB, 0x03, 0xFD, 0x8E, 0xB8, 0x8C, 0x7E, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
-    0x44, 0xAE, 0x42, 0x60, 0x82,
-];
+fn red_square_png(side: u32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut buf, side, side);
+        encoder.set_color(png::ColorType::Rgb);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().expect("png header");
+        let pixels: Vec<u8> = (0..side * side)
+            .flat_map(|_| [0xCC_u8, 0x22, 0x22])
+            .collect();
+        writer.write_image_data(&pixels).expect("png pixels");
+    }
+    buf
+}
 
 fn main() -> DocxResult<()> {
-    let png = TINY_PNG.to_vec();
+    let png = red_square_png(32);
 
     let mut docx = Docx::default();
-    let rid = docx.add_image("dot.png", MediaType::Image, &png);
-    let drawing = Pic::new(rid).name("dot").size_px(32, 32).into_drawing();
+    let rid = docx.add_image("square.png", MediaType::Image, &png);
+    let drawing = Pic::new(rid).name("square").size_px(32, 32).into_drawing();
 
     let para = Paragraph::default()
-        .push(Run::default().push_text("Behold a tiny dot: "))
+        .push(Run::default().push_text("Behold a red square: "))
         .push(Run::default().push_image(drawing));
     docx.document.push(para);
 

--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -36,10 +36,7 @@ impl<'a> Body<'a> {
     /// guaranteed without forcing every caller to walk the content
     /// vector.
     pub fn last_section_property_mut_or_create(&mut self) -> &mut SectionProperty<'a> {
-        let last_is_sect_pr = matches!(
-            self.content.last(),
-            Some(BodyContent::SectionProperty(_))
-        );
+        let last_is_sect_pr = matches!(self.content.last(), Some(BodyContent::SectionProperty(_)));
         if !last_is_sect_pr {
             self.content
                 .push(BodyContent::SectionProperty(SectionProperty::default()));

--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -26,6 +26,30 @@ impl<'a> Body<'a> {
         self
     }
 
+    /// Return the trailing `<w:sectPr>` of this body, creating an
+    /// empty one if absent.
+    ///
+    /// Headers and footers are wired into a section via
+    /// `<w:headerReference>` / `<w:footerReference>` children of a
+    /// `<w:sectPr>`. A well-formed document has exactly one section
+    /// property at the end of the body; this helper makes that
+    /// guaranteed without forcing every caller to walk the content
+    /// vector.
+    pub fn last_section_property_mut_or_create(&mut self) -> &mut SectionProperty<'a> {
+        let last_is_sect_pr = matches!(
+            self.content.last(),
+            Some(BodyContent::SectionProperty(_))
+        );
+        if !last_is_sect_pr {
+            self.content
+                .push(BodyContent::SectionProperty(SectionProperty::default()));
+        }
+        match self.content.last_mut() {
+            Some(BodyContent::SectionProperty(sp)) => sp,
+            _ => unreachable!("just pushed or matched a SectionProperty"),
+        }
+    }
+
     pub fn text(&self) -> String {
         let v: Vec<_> = self
             .content

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -18,6 +18,7 @@ mod header_footer_reference;
 mod hyperlink;
 mod instrtext;
 mod numbering;
+mod page_field;
 mod paragraph;
 mod run;
 mod sdt;
@@ -33,6 +34,7 @@ mod theme;
 pub use self::{
     body::*, bookmark_end::*, bookmark_start::*, comment_range::*, comments::*, document::*,
     drawing::*, endnotes::*, field_char::*, footer::*, footnotes::*, grid_column::*, header::*,
-    header_footer_reference::*, hyperlink::*, numbering::*, paragraph::*, r#break::*, run::*,
-    sdt::*, tab::*, table::*, table_cell::*, table_grid::*, table_row::*, text::*, theme::*,
+    header_footer_reference::*, hyperlink::*, numbering::*, page_field::*, paragraph::*,
+    r#break::*, run::*, sdt::*, tab::*, table::*, table_cell::*, table_grid::*, table_row::*,
+    text::*, theme::*,
 };

--- a/src/document/page_field.rs
+++ b/src/document/page_field.rs
@@ -1,0 +1,62 @@
+//! Field-code helpers for page numbering in headers and footers.
+//!
+//! Word represents a simple field like `{ PAGE }` as a sequence of
+//! three run-content elements:
+//!
+//! 1. `<w:fldChar w:fldCharType="begin"/>`
+//! 2. `<w:instrText> PAGE </w:instrText>`
+//! 3. `<w:fldChar w:fldCharType="end"/>`
+//!
+//! These helpers build a single [`Run`] containing that sequence,
+//! ready to push into a [`Paragraph`](crate::document::Paragraph). Word
+//! recomputes the displayed value on open or when the user presses F9.
+//!
+//! ```rust
+//! use docx_rust::document::{Paragraph, Run, page_field, num_pages_field};
+//!
+//! let footer_para = Paragraph::default()
+//!     .push(Run::default().push_text("Page "))
+//!     .push(page_field())
+//!     .push(Run::default().push_text(" of "))
+//!     .push(num_pages_field());
+//! ```
+
+use std::borrow::Cow;
+
+use crate::document::{
+    field_char::{CharType, FieldChar},
+    instrtext::{InstrText, TextSpace},
+    Run, RunContent,
+};
+
+/// A run containing a `{ PAGE }` field. Word substitutes the current
+/// page number at render time.
+pub fn page_field<'a>() -> Run<'a> {
+    field_run(" PAGE ")
+}
+
+/// A run containing a `{ NUMPAGES }` field. Word substitutes the
+/// total page count at render time.
+pub fn num_pages_field<'a>() -> Run<'a> {
+    field_run(" NUMPAGES ")
+}
+
+/// Build a run holding an arbitrary simple Word field. The provided
+/// instruction string is wrapped in `begin`/`end` field-char markers
+/// with `xml:space="preserve"` so leading and trailing spaces survive.
+///
+/// Use [`page_field`] / [`num_pages_field`] for the common cases.
+pub fn field_run<'a>(instr: impl Into<Cow<'a, str>>) -> Run<'a> {
+    let mut run = Run::default();
+    run.content.push(RunContent::FieldChar(FieldChar {
+        ty: Some(CharType::Begin),
+    }));
+    run.content.push(RunContent::InstrText(InstrText {
+        space: Some(TextSpace::Preserve),
+        text: instr.into(),
+    }));
+    run.content.push(RunContent::FieldChar(FieldChar {
+        ty: Some(CharType::End),
+    }));
+    run
+}

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -4,13 +4,13 @@ use hard_xml::{XmlRead, XmlWrite};
 use std::borrow::{Borrow, Cow};
 
 use crate::{
-    __setter, __xml_test_suites,
+    __define_enum, __define_struct, __setter, __xml_test_suites,
     document::{
         drawing::Drawing, field_char::FieldChar, instrtext::InstrText, r#break::Break,
         r#break::LastRenderedPageBreak, tab::Tab, text::Text,
     },
     formatting::CharacterProperty,
-    DocxResult, __define_enum, __define_struct,
+    DocxResult,
 };
 
 use super::{

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -116,6 +116,15 @@ impl<'a> Run<'a> {
         self
     }
 
+    /// Append a `<w:tab/>` tab character. Useful for splitting a
+    /// header or footer paragraph into left- and right-aligned
+    /// halves via the section's default tab stops.
+    #[inline(always)]
+    pub fn push_tab(mut self) -> Self {
+        self.content.push(RunContent::Tab(Tab));
+        self
+    }
+
     pub fn text(&self) -> String {
         self.iter_text()
             .map(|c| c.to_string())

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -108,6 +108,14 @@ impl<'a> Run<'a> {
         self
     }
 
+    /// Append an inline drawing (typically built via
+    /// [`Pic::into_drawing`](crate::media::Pic::into_drawing)).
+    #[inline(always)]
+    pub fn push_image(mut self, drawing: Drawing<'a>) -> Self {
+        self.content.push(RunContent::Drawing(drawing));
+        self
+    }
+
     pub fn text(&self) -> String {
         self.iter_text()
             .map(|c| c.to_string())

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -11,11 +11,14 @@ use std::path::Path;
 use zip::write::SimpleFileOptions;
 use zip::{result::ZipError, CompressionMethod, ZipArchive, ZipWriter};
 
-use crate::document::{Comments, EndNotes, FootNotes, Footer, Header, Numbering, Theme};
+use crate::document::{
+    Comments, EndNotes, FootNotes, Footer, FooterReference, Header, HeaderFooterReference,
+    HeaderFooterReferenceType, HeaderReference, Numbering, Theme,
+};
 use crate::media::MediaType;
 use crate::schema::{
-    SCHEMA_COMMENTS, SCHEMA_ENDNOTES, SCHEMA_FOOTNOTES, SCHEMA_HEADER, SCHEMA_NUMBERING,
-    SCHEMA_SETTINGS, SCHEMA_THEME, SCHEMA_WEB_SETTINGS,
+    SCHEMA_COMMENTS, SCHEMA_ENDNOTES, SCHEMA_FOOTER, SCHEMA_FOOTNOTES, SCHEMA_HEADER,
+    SCHEMA_NUMBERING, SCHEMA_SETTINGS, SCHEMA_THEME, SCHEMA_WEB_SETTINGS,
 };
 use crate::settings::Settings;
 use crate::web_settings::WebSettings;
@@ -142,7 +145,7 @@ impl<'a> Docx<'a> {
         for ft in &self.footers {
             self.document_rels
                 .get_or_insert(Relationships::default())
-                .add_rel(SCHEMA_HEADER, ft.0);
+                .add_rel(SCHEMA_FOOTER, ft.0);
         }
 
         for theme in &self.themes {
@@ -292,6 +295,123 @@ impl<'a> Docx<'a> {
             .add_rel_returning_id(Cow::Borrowed(schema), path)
     }
 
+    /// Register a footer with the default reference type
+    /// (`HeaderFooterReferenceType::Default` — applies to every page).
+    ///
+    /// See [`Docx::add_footer_with_type`] for first-page-only or
+    /// even-page variants.
+    pub fn add_footer(&mut self, footer: Footer<'a>) -> String {
+        self.add_footer_with_type(footer, HeaderFooterReferenceType::Default)
+    }
+
+    /// Register a footer for a specific reference type.
+    ///
+    /// Auto-handles:
+    ///
+    /// * allocating the next `footerN.xml` slot in `self.footers`
+    /// * adding the relationship to `self.document_rels`
+    /// * registering the `Override` Content Types entry
+    /// * attaching a `<w:footerReference>` to the trailing
+    ///   `<w:sectPr>` of the body, creating one if necessary
+    ///
+    /// Returns the relationship id (`"rId12"` etc.).
+    pub fn add_footer_with_type(
+        &mut self,
+        footer: Footer<'a>,
+        ty: HeaderFooterReferenceType,
+    ) -> String {
+        let n = (1u32..)
+            .find(|i| !self.footers.contains_key(&format!("footer{}.xml", i)))
+            .expect("u32 range exhausted");
+        let part = format!("footer{}.xml", n);
+
+        self.footers.insert(part.clone(), footer);
+
+        let rid = self
+            .document_rels
+            .get_or_insert_with(Relationships::default)
+            .add_rel_returning_id(Cow::Borrowed(SCHEMA_FOOTER), part.clone());
+
+        self.ensure_part_override(
+            &format!("/word/{}", part),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml",
+        );
+
+        let reference = FooterReference {
+            ty: Some(ty),
+            id: Some(Cow::Owned(rid.clone())),
+        };
+        self.document
+            .body
+            .last_section_property_mut_or_create()
+            .header_footer_references
+            .push(HeaderFooterReference::Footer(reference));
+
+        rid
+    }
+
+    /// Register a header with the default reference type
+    /// (`HeaderFooterReferenceType::Default` — applies to every page).
+    ///
+    /// See [`Docx::add_header_with_type`] for first-page-only or
+    /// even-page variants.
+    pub fn add_header(&mut self, header: Header<'a>) -> String {
+        self.add_header_with_type(header, HeaderFooterReferenceType::Default)
+    }
+
+    /// Register a header for a specific reference type. Symmetric with
+    /// [`Docx::add_footer_with_type`].
+    pub fn add_header_with_type(
+        &mut self,
+        header: Header<'a>,
+        ty: HeaderFooterReferenceType,
+    ) -> String {
+        let n = (1u32..)
+            .find(|i| !self.headers.contains_key(&format!("header{}.xml", i)))
+            .expect("u32 range exhausted");
+        let part = format!("header{}.xml", n);
+
+        self.headers.insert(part.clone(), header);
+
+        let rid = self
+            .document_rels
+            .get_or_insert_with(Relationships::default)
+            .add_rel_returning_id(Cow::Borrowed(SCHEMA_HEADER), part.clone());
+
+        self.ensure_part_override(
+            &format!("/word/{}", part),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml",
+        );
+
+        let reference = HeaderReference {
+            ty: Some(ty),
+            id: Some(Cow::Owned(rid.clone())),
+        };
+        self.document
+            .body
+            .last_section_property_mut_or_create()
+            .header_footer_references
+            .push(HeaderFooterReference::Header(reference));
+
+        rid
+    }
+
+    fn ensure_part_override(&mut self, partname: &str, content_type: &'static str) {
+        let already = self
+            .content_types
+            .overrides
+            .iter()
+            .any(|o| o.part == partname);
+        if !already {
+            self.content_types
+                .overrides
+                .push(crate::content_type::OverrideContentType {
+                    part: Cow::Owned(partname.to_string()),
+                    ty: Cow::Borrowed(content_type),
+                });
+        }
+    }
+
     fn ensure_image_content_type(&mut self, ext: &str) {
         let mime = match ext {
             "png" => "image/png",
@@ -393,7 +513,7 @@ impl<'a> Docx<'a> {
         for ft in &self.footers {
             self.document_rels
                 .get_or_insert(Relationships::default())
-                .add_rel(SCHEMA_HEADER, ft.0);
+                .add_rel(SCHEMA_FOOTER, ft.0);
         }
 
         for theme in &self.themes {

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -56,7 +56,7 @@ pub struct Docx<'a> {
     pub headers: HashMap<String, Header<'a>>,
     pub footers: HashMap<String, Footer<'a>>,
     pub themes: HashMap<String, Theme<'a>>,
-    pub media: HashMap<String, (MediaType, &'a Vec<u8>)>,
+    pub media: HashMap<String, (MediaType, &'a [u8])>,
     pub footnotes: Option<FootNotes<'a>>,
     pub endnotes: Option<EndNotes<'a>>,
     pub settings: Option<Settings<'a>>,
@@ -256,13 +256,27 @@ impl<'a> Docx<'a> {
     /// generated `.docx` opens as "corrupt" in Word.
     ///
     /// The image bytes are borrowed for the lifetime of the `Docx`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `filename` is not a leaf name (contains `/`, `\\`,
+    /// or `..`). This guards against zip-path traversal: a caller
+    /// passing `"../_rels/document.xml.rels"` would otherwise
+    /// overwrite an internal package part. Pass only the file's
+    /// basename — the helper places it under `word/media/` itself.
     pub fn add_image(
         &mut self,
         filename: impl Into<Cow<'a, str>>,
         media_type: MediaType,
-        bytes: &'a Vec<u8>,
+        bytes: &'a [u8],
     ) -> String {
         let filename = filename.into();
+        if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+            panic!(
+                "add_image filename must be a leaf name with no path separators or '..': {:?}",
+                filename
+            );
+        }
         let path = format!("media/{}", filename);
 
         if let Some(ext) = filename.rsplit('.').next() {
@@ -642,7 +656,7 @@ impl DocxFile {
             let mt = crate::media::get_media_type(&m.0);
             if let Some(mt) = mt {
                 let name = m.0.replace("word/", "");
-                let m = (mt, &m.1);
+                let m = (mt, m.1.as_slice());
                 media.insert(name, m);
             }
         }

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -313,6 +313,15 @@ impl<'a> Docx<'a> {
     /// * registering the `Override` Content Types entry
     /// * attaching a `<w:footerReference>` to the trailing
     ///   `<w:sectPr>` of the body, creating one if necessary
+    /// * for `First` types, also setting `<w:titlePg/>` on the
+    ///   trailing section properties — Word ignores a
+    ///   `w:type="first"` reference without this flag
+    /// * for `Even` types, also setting `<w:evenAndOddHeaders/>`
+    ///   on `word/settings.xml` — Word ignores a `w:type="even"`
+    ///   reference without this setting
+    /// * if a footer of the same type already exists for this
+    ///   section, the old reference is replaced rather than
+    ///   appended (Word treats duplicates inconsistently)
     ///
     /// Returns the relationship id (`"rId12"` etc.).
     pub fn add_footer_with_type(
@@ -338,14 +347,15 @@ impl<'a> Docx<'a> {
         );
 
         let reference = FooterReference {
-            ty: Some(ty),
+            ty: Some(ty.clone()),
             id: Some(Cow::Owned(rid.clone())),
         };
-        self.document
-            .body
-            .last_section_property_mut_or_create()
-            .header_footer_references
-            .push(HeaderFooterReference::Footer(reference));
+        let sect_pr = self.document.body.last_section_property_mut_or_create();
+        replace_footer_reference_of_type(&mut sect_pr.header_footer_references, &ty, reference);
+        if matches!(ty, HeaderFooterReferenceType::First) {
+            sect_pr.title_page = Some(crate::formatting::TitlePage::default());
+        }
+        self.ensure_settings_for_type(&ty);
 
         rid
     }
@@ -360,7 +370,10 @@ impl<'a> Docx<'a> {
     }
 
     /// Register a header for a specific reference type. Symmetric with
-    /// [`Docx::add_footer_with_type`].
+    /// [`Docx::add_footer_with_type`] — see that method for the full
+    /// list of side-effects (Content Types, rels, section reference,
+    /// `titlePg` for First, `evenAndOddHeaders` for Even, replace
+    /// existing reference of same type rather than append).
     pub fn add_header_with_type(
         &mut self,
         header: Header<'a>,
@@ -384,16 +397,26 @@ impl<'a> Docx<'a> {
         );
 
         let reference = HeaderReference {
-            ty: Some(ty),
+            ty: Some(ty.clone()),
             id: Some(Cow::Owned(rid.clone())),
         };
-        self.document
-            .body
-            .last_section_property_mut_or_create()
-            .header_footer_references
-            .push(HeaderFooterReference::Header(reference));
+        let sect_pr = self.document.body.last_section_property_mut_or_create();
+        replace_header_reference_of_type(&mut sect_pr.header_footer_references, &ty, reference);
+        if matches!(ty, HeaderFooterReferenceType::First) {
+            sect_pr.title_page = Some(crate::formatting::TitlePage::default());
+        }
+        self.ensure_settings_for_type(&ty);
 
         rid
+    }
+
+    fn ensure_settings_for_type(&mut self, ty: &HeaderFooterReferenceType) {
+        if matches!(ty, HeaderFooterReferenceType::Even) {
+            let settings = self.settings.get_or_insert_with(Settings::default);
+            if settings.even_and_odd_headers.is_none() {
+                settings.even_and_odd_headers = Some(crate::settings::EvenAndOddHeaders::default());
+            }
+        }
     }
 
     fn ensure_part_override(&mut self, partname: &str, content_type: &'static str) {
@@ -435,6 +458,47 @@ impl<'a> Docx<'a> {
                     ty: Cow::Borrowed(mime),
                 });
         }
+    }
+}
+
+/// Replace any existing header reference of `ty`, then append the new
+/// one. Header- and footer-references coexist in one Vec discriminated
+/// by enum variant, so the helper only touches Header variants.
+fn replace_header_reference_of_type<'a>(
+    refs: &mut Vec<HeaderFooterReference<'a>>,
+    ty: &HeaderFooterReferenceType,
+    new_ref: HeaderReference<'a>,
+) {
+    refs.retain(|r| match r {
+        HeaderFooterReference::Header(h) => !matches_type(&h.ty, ty),
+        HeaderFooterReference::Footer(_) => true,
+    });
+    refs.push(HeaderFooterReference::Header(new_ref));
+}
+
+/// Footer-side counterpart to [`replace_header_reference_of_type`].
+fn replace_footer_reference_of_type<'a>(
+    refs: &mut Vec<HeaderFooterReference<'a>>,
+    ty: &HeaderFooterReferenceType,
+    new_ref: FooterReference<'a>,
+) {
+    refs.retain(|r| match r {
+        HeaderFooterReference::Footer(f) => !matches_type(&f.ty, ty),
+        HeaderFooterReference::Header(_) => true,
+    });
+    refs.push(HeaderFooterReference::Footer(new_ref));
+}
+
+fn matches_type(
+    found: &Option<HeaderFooterReferenceType>,
+    expected: &HeaderFooterReferenceType,
+) -> bool {
+    use HeaderFooterReferenceType::*;
+    match (found, expected) {
+        (Some(Default), Default) | (None, Default) => true,
+        (Some(First), First) => true,
+        (Some(Even), Even) => true,
+        _ => false,
     }
 }
 

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -243,6 +243,67 @@ impl<'a> Docx<'a> {
         let file = File::create(path)?;
         self.write(file)
     }
+
+    /// Register an image in the document's media store and return the
+    /// relationship id (e.g. `"rId12"`) that callers pass to
+    /// [`Pic::new`](crate::media::Pic::new).
+    ///
+    /// `filename` is the leaf name (e.g. `"cat.png"`); the helper
+    /// stores it under `media/<filename>` in the resulting zip.
+    ///
+    /// Auto-registers a `<Default>` Content Types entry for the file
+    /// extension if one is not already present. Without this the
+    /// generated `.docx` opens as "corrupt" in Word.
+    ///
+    /// The image bytes are borrowed for the lifetime of the `Docx`.
+    pub fn add_image(
+        &mut self,
+        filename: impl Into<Cow<'a, str>>,
+        media_type: MediaType,
+        bytes: &'a Vec<u8>,
+    ) -> String {
+        let filename = filename.into();
+        let path = format!("media/{}", filename);
+
+        if let Some(ext) = filename.rsplit('.').next() {
+            self.ensure_image_content_type(&ext.to_ascii_lowercase());
+        }
+
+        self.media.insert(path.clone(), (media_type, bytes));
+
+        let schema = crate::media::get_media_type_relation_type(
+            &self.media[&path].0,
+        );
+
+        self.document_rels
+            .get_or_insert_with(Relationships::default)
+            .add_rel_returning_id(Cow::Borrowed(schema), path)
+    }
+
+    fn ensure_image_content_type(&mut self, ext: &str) {
+        let mime = match ext {
+            "png" => "image/png",
+            "jpg" | "jpeg" => "image/jpeg",
+            "bmp" => "image/bmp",
+            "gif" => "image/gif",
+            "tif" | "tiff" => "image/tiff",
+            _ => return,
+        };
+
+        let already = self
+            .content_types
+            .defaults
+            .iter()
+            .any(|d| d.ext.eq_ignore_ascii_case(ext));
+        if !already {
+            self.content_types
+                .defaults
+                .push(crate::content_type::DefaultContentType {
+                    ext: Cow::Owned(ext.to_string()),
+                    ty: Cow::Borrowed(mime),
+                });
+        }
+    }
 }
 
 #[cfg(feature = "async")]

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -271,9 +271,7 @@ impl<'a> Docx<'a> {
 
         self.media.insert(path.clone(), (media_type, bytes));
 
-        let schema = crate::media::get_media_type_relation_type(
-            &self.media[&path].0,
-        );
+        let schema = crate::media::get_media_type_relation_type(&self.media[&path].0);
 
         self.document_rels
             .get_or_insert_with(Relationships::default)

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,5 +1,8 @@
 use crate::schema::SCHEMA_IMAGE;
 
+mod pic;
+pub use pic::{Pic, EMU_PER_INCH, EMU_PER_PIXEL};
+
 /// Specifies the type of a media file
 ///
 #[derive(Debug, Clone)]

--- a/src/media/pic.rs
+++ b/src/media/pic.rs
@@ -1,0 +1,177 @@
+//! Inline picture helper.
+//!
+//! Wraps the tedium of constructing the
+//! `Drawing → Inline → Graphic → Picture → BlipFill → Blip` XML chain
+//! for the common case of placing an image in a run.
+//!
+//! The helper does NOT register image bytes with the document; callers
+//! do that via [`Docx::add_image`](crate::Docx::add_image) to obtain
+//! the relationship id used here.
+//!
+//! ```no_run
+//! use docx_rust::Docx;
+//! use docx_rust::document::{Paragraph, Run};
+//! use docx_rust::media::{MediaType, Pic};
+//!
+//! # let png_bytes: Vec<u8> = vec![];
+//! let mut docx = Docx::default();
+//! let rid = docx.add_image("cat.png", MediaType::Image, &png_bytes);
+//! let drawing = Pic::new(rid).size_px(160, 120).into_drawing();
+//! let para = Paragraph::default()
+//!     .push(Run::default().push_image(drawing));
+//! docx.document.push(para);
+//! ```
+
+use std::borrow::Cow;
+
+use crate::document::{
+    Blip, BlipFill, CNvPicPr, CNvPr, DocPr, Drawing, Ext, Extent, FillRect, Graphic, GraphicData,
+    Inline, NvPicPr, Offset, Picture, PrstGeom, SpPr, Stretch, Xfrm,
+};
+use crate::schema::{SCHEMA_DRAWINGML, SCHEMA_PIC};
+
+/// English Metric Units per pixel at 96 DPI.
+pub const EMU_PER_PIXEL: u64 = 9_525;
+
+/// English Metric Units per inch.
+pub const EMU_PER_INCH: u64 = 914_400;
+
+/// Builder for an inline picture.
+///
+/// Sizes default to 16x16 pixels at 96 DPI; override with
+/// [`Pic::size_px`] or [`Pic::size_emu`].
+pub struct Pic<'a> {
+    rid: Cow<'a, str>,
+    name: Cow<'a, str>,
+    descr: Option<Cow<'a, str>>,
+    width_emu: u64,
+    height_emu: u64,
+    doc_id: isize,
+}
+
+impl<'a> Pic<'a> {
+    /// Create a builder from a relationship id previously returned by
+    /// [`Docx::add_image`](crate::Docx::add_image).
+    pub fn new(rid: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            rid: rid.into(),
+            name: Cow::Borrowed("image"),
+            descr: None,
+            width_emu: 16 * EMU_PER_PIXEL,
+            height_emu: 16 * EMU_PER_PIXEL,
+            doc_id: 1,
+        }
+    }
+
+    /// Set the picture display name (appears in `wp:docPr` / `pic:cNvPr`).
+    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Set the alt-text description.
+    pub fn descr(mut self, descr: impl Into<Cow<'a, str>>) -> Self {
+        self.descr = Some(descr.into());
+        self
+    }
+
+    /// Set size in pixels at 96 DPI. Internally converts to EMU.
+    pub fn size_px(mut self, w: u64, h: u64) -> Self {
+        self.width_emu = w * EMU_PER_PIXEL;
+        self.height_emu = h * EMU_PER_PIXEL;
+        self
+    }
+
+    /// Set size directly in English Metric Units.
+    pub fn size_emu(mut self, w: u64, h: u64) -> Self {
+        self.width_emu = w;
+        self.height_emu = h;
+        self
+    }
+
+    /// Set the document-wide unique picture id. Defaults to 1; bump
+    /// when embedding multiple images in the same document.
+    pub fn doc_id(mut self, id: isize) -> Self {
+        self.doc_id = id;
+        self
+    }
+
+    /// Build the [`Drawing`] ready to push into a [`Run`](crate::document::Run).
+    pub fn into_drawing(self) -> Drawing<'a> {
+        let Pic {
+            rid,
+            name,
+            descr,
+            width_emu,
+            height_emu,
+            doc_id,
+        } = self;
+
+        let cx = width_emu as isize;
+        let cy = height_emu as isize;
+
+        let picture = Picture {
+            a: Cow::Borrowed(SCHEMA_PIC),
+            nv_pic_pr: NvPicPr {
+                c_nv_pr: Some(CNvPr {
+                    id: Some(doc_id),
+                    name: Some(name.clone()),
+                    descr: descr.clone(),
+                }),
+                c_nv_pic_pr: Some(CNvPicPr::default()),
+            },
+            fill: BlipFill {
+                blip: Blip {
+                    embed: rid,
+                    cstate: None,
+                },
+                stretch: Some(Stretch {
+                    fill_rect: Some(FillRect::default()),
+                }),
+            },
+            sp_pr: SpPr {
+                xfrm: Some(Xfrm {
+                    offset: Some(Offset {
+                        x: Some(0),
+                        y: Some(0),
+                    }),
+                    ext: Some(Ext {
+                        cx: Some(cx),
+                        cy: Some(cy),
+                    }),
+                }),
+                prst_geom: Some(PrstGeom {
+                    prst: Some(Cow::Borrowed("rect")),
+                    av_lst: None,
+                }),
+            },
+        };
+
+        let graphic = Graphic {
+            a: Cow::Borrowed(SCHEMA_DRAWINGML),
+            data: GraphicData {
+                uri: Cow::Borrowed(SCHEMA_PIC),
+                children: vec![picture],
+            },
+        };
+
+        let inline = Inline {
+            extent: Some(Extent {
+                cx: width_emu,
+                cy: height_emu,
+            }),
+            doc_property: DocPr {
+                id: Some(doc_id),
+                name: Some(name),
+                descr,
+            },
+            graphic: Some(graphic),
+            ..Inline::default()
+        };
+
+        Drawing {
+            anchor: None,
+            inline: Some(inline),
+        }
+    }
+}

--- a/src/media/pic.rs
+++ b/src/media/pic.rs
@@ -46,7 +46,7 @@ pub struct Pic<'a> {
     descr: Option<Cow<'a, str>>,
     width_emu: u64,
     height_emu: u64,
-    doc_id: isize,
+    doc_id: u32,
 }
 
 impl<'a> Pic<'a> {
@@ -76,9 +76,15 @@ impl<'a> Pic<'a> {
     }
 
     /// Set size in pixels at 96 DPI. Internally converts to EMU.
+    ///
+    /// Saturates at `u64::MAX` if the multiplication overflows, so a
+    /// pathological caller cannot panic the builder. The resulting
+    /// EMU value will exceed Word's max image dimension and the
+    /// document will simply render that picture clamped to the page,
+    /// which is the right failure mode for unrealistic sizes.
     pub fn size_px(mut self, w: u64, h: u64) -> Self {
-        self.width_emu = w * EMU_PER_PIXEL;
-        self.height_emu = h * EMU_PER_PIXEL;
+        self.width_emu = w.saturating_mul(EMU_PER_PIXEL);
+        self.height_emu = h.saturating_mul(EMU_PER_PIXEL);
         self
     }
 
@@ -91,7 +97,10 @@ impl<'a> Pic<'a> {
 
     /// Set the document-wide unique picture id. Defaults to 1; bump
     /// when embedding multiple images in the same document.
-    pub fn doc_id(mut self, id: isize) -> Self {
+    ///
+    /// `wp:docPr/@id` and `pic:cNvPr/@id` are both unsigned in the
+    /// OOXML schema; `u32` matches that contract.
+    pub fn doc_id(mut self, id: u32) -> Self {
         self.doc_id = id;
         self
     }
@@ -107,14 +116,22 @@ impl<'a> Pic<'a> {
             doc_id,
         } = self;
 
-        let cx = width_emu as isize;
-        let cy = height_emu as isize;
+        // The XML uses `Option<isize>` for these fields. Saturate
+        // rather than wrap if a caller passed an absurdly large EMU
+        // value: an overflow-wrap would emit a negative cx/cy and
+        // Word would treat the picture as zero-sized or invalid.
+        let cx = isize::try_from(width_emu).unwrap_or(isize::MAX);
+        let cy = isize::try_from(height_emu).unwrap_or(isize::MAX);
+        // doc_id is u32 from the public API; widening to isize for
+        // the XML attribute is always lossless on 64-bit, and on
+        // 32-bit isize::MAX > u32::MAX/2 so values up to 2^31-1 fit.
+        let id = isize::try_from(doc_id).unwrap_or(isize::MAX);
 
         let picture = Picture {
             a: Cow::Borrowed(SCHEMA_PIC),
             nv_pic_pr: NvPicPr {
                 c_nv_pr: Some(CNvPr {
-                    id: Some(doc_id),
+                    id: Some(id),
                     name: Some(name.clone()),
                     descr: descr.clone(),
                 }),
@@ -161,7 +178,7 @@ impl<'a> Pic<'a> {
                 cy: height_emu,
             }),
             doc_property: DocPr {
-                id: Some(doc_id),
+                id: Some(id),
                 name: Some(name),
                 descr,
             },

--- a/src/rels.rs
+++ b/src/rels.rs
@@ -116,6 +116,44 @@ impl<'a> Relationships<'a> {
             .find(|r| r.id == id)
             .map(|r| &*r.target)
     }
+
+    /// Insert a relationship and return the assigned `rIdN`.
+    ///
+    /// If a relationship to the same target already exists, the
+    /// existing id is returned and no new entry is created.
+    ///
+    /// Unlike [`Relationships::add_rel`], this does not require the
+    /// schema and target to outlive the relationships table — owned
+    /// strings are accepted via [`Cow`].
+    pub fn add_rel_returning_id(
+        &mut self,
+        schema: impl Into<Cow<'a, str>>,
+        target: impl Into<Cow<'a, str>>,
+    ) -> String {
+        let schema = schema.into();
+        let target = target.into();
+
+        if let Some(existing) = self.relationships.iter().find(|r| r.target == target) {
+            return existing.id.to_string();
+        }
+
+        let mut id = self.relationships.len();
+        let new_id = loop {
+            id += 1;
+            let candidate = format!("rId{}", id);
+            if !self.relationships.iter().any(|r| r.id == candidate) {
+                break candidate;
+            }
+        };
+
+        self.relationships.push(Relationship {
+            id: Cow::Owned(new_id.clone()),
+            target,
+            ty: schema,
+            target_mode: None,
+        });
+        new_id
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -12,6 +12,7 @@ pub const SCHEMA_CONTENT_TYPES: &str =
 pub const SCHEMA_MAIN: &str = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 pub const SCHEMA_WORDML_14: &str = "http://schemas.microsoft.com/office/word/2010/wordml";
 pub const SCHEMA_DRAWINGML: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+pub const SCHEMA_PIC: &str = "http://schemas.openxmlformats.org/drawingml/2006/picture";
 pub const SCHEMA_WP: &str =
     "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing";
 pub const SCHEMA_RELATIONSHIPS_DOCUMENT: &str =

--- a/tests/header_footer_test.rs
+++ b/tests/header_footer_test.rs
@@ -175,6 +175,76 @@ fn first_page_footer_uses_first_reference_type() {
         "first-page footer ref type missing: {}",
         doc
     );
+    // Without `<w:titlePg/>` Word silently ignores a `w:type="first"`
+    // reference. The helper must auto-add it.
+    assert!(
+        doc.contains("<w:titlePg"),
+        "first-page reference type without <w:titlePg/>: Word will ignore it. doc.xml: {}",
+        doc
+    );
+}
+
+#[test]
+fn even_page_header_writes_even_and_odd_headers_setting() {
+    let mut docx = Docx::default();
+    docx.document
+        .push(Paragraph::default().push(Run::default().push_text("body")));
+
+    let mut header = Header::default();
+    header.push(Paragraph::default().push(Run::default().push_text("even")));
+    docx.add_header_with_type(header, HeaderFooterReferenceType::Even);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    // Without `<w:evenAndOddHeaders/>` in settings.xml Word silently
+    // ignores `w:type="even"` references.
+    let settings = zip
+        .by_name("word/settings.xml")
+        .map(|mut e| {
+            let mut s = String::new();
+            std::io::Read::read_to_string(&mut e, &mut s).unwrap();
+            s
+        })
+        .expect("settings.xml must be written when an even-page reference is added");
+    assert!(
+        settings.contains("<w:evenAndOddHeaders"),
+        "evenAndOddHeaders missing from settings.xml: {}",
+        settings
+    );
+}
+
+#[test]
+fn registering_two_footers_of_the_same_type_replaces_the_old_reference() {
+    let mut docx = Docx::default();
+    docx.document
+        .push(Paragraph::default().push(Run::default().push_text("body")));
+
+    // First registration of type Default.
+    let mut a = Footer::default();
+    a.push(Paragraph::default().push(Run::default().push_text("v1")));
+    docx.add_footer(a);
+
+    // Second registration of the same type. Should replace the
+    // section reference, not stack two of them.
+    let mut b = Footer::default();
+    b.push(Paragraph::default().push(Run::default().push_text("v2")));
+    docx.add_footer(b);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+    let doc = read_part(&mut zip, "word/document.xml");
+
+    let count = doc
+        .matches(r#"<w:footerReference w:type="default""#)
+        .count();
+    assert_eq!(
+        count, 1,
+        "expected exactly one default footerReference; got {} in doc.xml: {}",
+        count, doc
+    );
 }
 
 #[test]

--- a/tests/header_footer_test.rs
+++ b/tests/header_footer_test.rs
@@ -50,7 +50,10 @@ fn add_footer_writes_part_rel_override_and_section_reference() {
     let cursor = Cursor::new(bytes.as_slice());
     let mut zip = ZipArchive::new(cursor).unwrap();
 
-    assert!(zip.by_name("word/footer1.xml").is_ok(), "footer1.xml missing");
+    assert!(
+        zip.by_name("word/footer1.xml").is_ok(),
+        "footer1.xml missing"
+    );
 
     let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
     assert!(rels.contains(r#"Target="footer1.xml""#));
@@ -111,7 +114,10 @@ fn add_header_writes_part_rel_override_and_section_reference() {
     let cursor = Cursor::new(bytes.as_slice());
     let mut zip = ZipArchive::new(cursor).unwrap();
 
-    assert!(zip.by_name("word/header1.xml").is_ok(), "header1.xml missing");
+    assert!(
+        zip.by_name("word/header1.xml").is_ok(),
+        "header1.xml missing"
+    );
 
     let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
     assert!(rels.contains(r#"Target="header1.xml""#));
@@ -196,8 +202,12 @@ fn two_footers_get_distinct_part_names() {
 #[test]
 fn run_push_tab_emits_tab_element() {
     let mut docx = Docx::default();
-    let para = Paragraph::default()
-        .push(Run::default().push_text("left").push_tab().push_text("right"));
+    let para = Paragraph::default().push(
+        Run::default()
+            .push_text("left")
+            .push_tab()
+            .push_text("right"),
+    );
     docx.document.push(para);
     let bytes = write_to_zip(&mut docx);
     let cursor = Cursor::new(bytes.as_slice());

--- a/tests/header_footer_test.rs
+++ b/tests/header_footer_test.rs
@@ -1,0 +1,207 @@
+//! End-to-end tests for header / footer ergonomics
+//! (`Docx::add_header`, `Docx::add_footer`, `page_field`,
+//! `num_pages_field`, `Run::push_tab`, and the
+//! `SCHEMA_HEADER` -> `SCHEMA_FOOTER` bug fix in the write loop).
+
+use std::io::{Cursor, Read};
+
+use docx_rust::{
+    document::{
+        num_pages_field, page_field, Footer, Header, HeaderFooterReferenceType, Paragraph, Run,
+    },
+    Docx,
+};
+use zip::ZipArchive;
+
+fn write_to_zip<'a>(docx: &'a mut Docx<'a>) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let result = docx.write(buf).expect("write docx");
+    result.into_inner()
+}
+
+fn read_part(zip: &mut ZipArchive<Cursor<&[u8]>>, name: &str) -> String {
+    let mut entry = zip.by_name(name).expect(name);
+    let mut s = String::new();
+    entry.read_to_string(&mut s).unwrap();
+    s
+}
+
+fn build_minimal_with_footer() -> Vec<u8> {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut footer = Footer::default();
+    footer.push(
+        Paragraph::default()
+            .push(Run::default().push_text("Page "))
+            .push(page_field())
+            .push(Run::default().push_text(" of "))
+            .push(num_pages_field()),
+    );
+    let _rid = docx.add_footer(footer);
+
+    write_to_zip(&mut docx)
+}
+
+#[test]
+fn add_footer_writes_part_rel_override_and_section_reference() {
+    let bytes = build_minimal_with_footer();
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(zip.by_name("word/footer1.xml").is_ok(), "footer1.xml missing");
+
+    let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
+    assert!(rels.contains(r#"Target="footer1.xml""#));
+    assert!(
+        rels.contains("/relationships/footer"),
+        "footer rel schema missing: {}",
+        rels
+    );
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(
+        cts.contains(r#"PartName="/word/footer1.xml""#)
+            && cts.contains("wordprocessingml.footer+xml"),
+        "footer Override missing: {}",
+        cts
+    );
+
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(
+        doc.contains("<w:footerReference") && doc.contains(r#"w:type="default""#),
+        "footerReference missing in sectPr: {}",
+        doc
+    );
+}
+
+#[test]
+fn footer_contains_page_and_numpages_field_codes() {
+    let bytes = build_minimal_with_footer();
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let footer = read_part(&mut zip, "word/footer1.xml");
+    assert!(footer.contains(r#"<w:fldChar w:fldCharType="begin"/>"#));
+    assert!(footer.contains(r#"<w:fldChar w:fldCharType="end"/>"#));
+    assert!(
+        footer.contains("PAGE") && footer.contains("NUMPAGES"),
+        "field instructions missing: {}",
+        footer
+    );
+    assert!(
+        footer.contains(r#"xml:space="preserve""#),
+        "instr text missing space=preserve (Word may strip leading/trailing spaces): {}",
+        footer
+    );
+}
+
+#[test]
+fn add_header_writes_part_rel_override_and_section_reference() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut header = Header::default();
+    header.push(Paragraph::default().push(Run::default().push_text("HEADER TEXT")));
+    let _rid = docx.add_header(header);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(zip.by_name("word/header1.xml").is_ok(), "header1.xml missing");
+
+    let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
+    assert!(rels.contains(r#"Target="header1.xml""#));
+    assert!(rels.contains("/relationships/header"));
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(cts.contains(r#"PartName="/word/header1.xml""#));
+    assert!(cts.contains("wordprocessingml.header+xml"));
+
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(doc.contains("<w:headerReference"));
+}
+
+#[test]
+fn header_and_footer_can_coexist_in_one_section() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut header = Header::default();
+    header.push(Paragraph::default().push(Run::default().push_text("H")));
+    let h_rid = docx.add_header(header);
+
+    let mut footer = Footer::default();
+    footer.push(Paragraph::default().push(Run::default().push_text("F")));
+    let f_rid = docx.add_footer(footer);
+
+    assert_ne!(h_rid, f_rid, "header and footer rids must differ");
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(doc.contains("<w:headerReference"));
+    assert!(doc.contains("<w:footerReference"));
+}
+
+#[test]
+fn first_page_footer_uses_first_reference_type() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut footer = Footer::default();
+    footer.push(Paragraph::default().push(Run::default().push_text("first-page-only")));
+    docx.add_footer_with_type(footer, HeaderFooterReferenceType::First);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(
+        doc.contains(r#"<w:footerReference w:type="first""#),
+        "first-page footer ref type missing: {}",
+        doc
+    );
+}
+
+#[test]
+fn two_footers_get_distinct_part_names() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut a = Footer::default();
+    a.push(Paragraph::default().push(Run::default().push_text("default")));
+    docx.add_footer(a);
+
+    let mut b = Footer::default();
+    b.push(Paragraph::default().push(Run::default().push_text("first")));
+    docx.add_footer_with_type(b, HeaderFooterReferenceType::First);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(zip.by_name("word/footer1.xml").is_ok());
+    assert!(zip.by_name("word/footer2.xml").is_ok());
+}
+
+#[test]
+fn run_push_tab_emits_tab_element() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default()
+        .push(Run::default().push_text("left").push_tab().push_text("right"));
+    docx.document.push(para);
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(doc.contains("<w:tab/>"), "expected <w:tab/>: {}", doc);
+}

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -1,0 +1,131 @@
+//! End-to-end tests for the image-embedding ergonomics
+//! (`Docx::add_image`, `Pic`, `Run::push_image`).
+//!
+//! Tests serialise the document into an in-memory zip, then parse the
+//! resulting parts as XML to assert presence of relationships, content
+//! types, and the drawing chain.
+
+use std::io::Cursor;
+
+use docx_rust::{
+    document::{Paragraph, Run},
+    media::{MediaType, Pic},
+    Docx,
+};
+use zip::ZipArchive;
+
+/// Smallest valid PNG (1x1 transparent).
+const PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0x0F, 0x04, 0x00,
+    0x00, 0x09, 0xFB, 0x03, 0xFD, 0x8E, 0xB8, 0x8C, 0x7E, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+fn write_to_zip<'a>(docx: &'a mut Docx<'a>) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let result = docx.write(buf).expect("write docx");
+    result.into_inner()
+}
+
+fn read_part(zip: &mut ZipArchive<Cursor<&[u8]>>, name: &str) -> String {
+    use std::io::Read;
+    let mut entry = zip.by_name(name).expect(name);
+    let mut s = String::new();
+    entry.read_to_string(&mut s).unwrap();
+    s
+}
+
+#[test]
+fn single_image_registers_media_rel_and_content_type() {
+    let png = PNG.to_vec();
+    let mut docx = Docx::default();
+
+    let rid = docx.add_image("dot.png", MediaType::Image, &png);
+    let drawing = Pic::new(rid.clone()).size_px(16, 16).into_drawing();
+    let para = Paragraph::default().push(Run::default().push_image(drawing));
+    docx.document.push(para);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(
+        zip.by_name("word/media/dot.png").is_ok(),
+        "image bytes missing from zip"
+    );
+
+    let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
+    assert!(
+        rels.contains(&format!(r#"Id="{}""#, rid)),
+        "rel id {} missing in {}",
+        rid,
+        rels
+    );
+    assert!(rels.contains(r#"Target="media/dot.png""#));
+    assert!(rels.contains("/relationships/image"));
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(
+        cts.contains(r#"Extension="png""#) && cts.contains(r#"ContentType="image/png""#),
+        "png Default not registered: {}",
+        cts
+    );
+
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(doc.contains(r#"r:embed="rId1""#) || doc.contains(&format!(r#"r:embed="{}""#, rid)));
+    assert!(doc.contains("<w:drawing>"));
+    assert!(doc.contains("<pic:pic"));
+}
+
+#[test]
+fn ten_images_get_distinct_rids_and_one_content_type() {
+    let png = PNG.to_vec();
+    let mut docx = Docx::default();
+
+    let mut rids = Vec::new();
+    for i in 0..10 {
+        let name = format!("img{}.png", i);
+        let rid = docx.add_image(name, MediaType::Image, &png);
+        rids.push(rid.clone());
+        let drawing = Pic::new(rid).doc_id(i + 1).into_drawing();
+        let para = Paragraph::default().push(Run::default().push_image(drawing));
+        docx.document.push(para);
+    }
+
+    let unique: std::collections::HashSet<_> = rids.iter().collect();
+    assert_eq!(unique.len(), 10, "rids must be distinct: {:?}", rids);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    let png_default_count = cts.matches(r#"Extension="png""#).count();
+    assert_eq!(png_default_count, 1, "png Default duplicated: {}", cts);
+}
+
+#[test]
+fn jpeg_extension_registers_image_jpeg_content_type() {
+    let bytes = vec![0xFF, 0xD8, 0xFF, 0xE0]; // not a valid JPEG but irrelevant for the test
+    let mut docx = Docx::default();
+    let _rid = docx.add_image("photo.jpg", MediaType::Image, &bytes);
+
+    let zip_bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(zip_bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(cts.contains(r#"Extension="jpg""#));
+    assert!(cts.contains(r#"ContentType="image/jpeg""#));
+}
+
+#[test]
+fn pic_size_px_converts_to_emu() {
+    let drawing = Pic::new("rId99").size_px(100, 50).into_drawing();
+    let inline = drawing.inline.expect("inline");
+    let extent = inline.extent.expect("extent");
+    assert_eq!(extent.cx, 100 * 9_525);
+    assert_eq!(extent.cy, 50 * 9_525);
+}


### PR DESCRIPTION
**Stacked on top of #55** (image-ergonomics). Please review #55 first; the first commit on this branch is identical to that PR. Once #55 merges, this PR will rebase to a single commit.

## Why

Wiring a header or footer into a document today requires hand-managing the part filename, the document relationship, the Content Types Override, and the section-property reference — four moving pieces, none of which the existing \`Header\` / \`Footer\` types help with. \`Page X of Y\` field codes likewise require a hand-built \`begin\` / \`instrText\` / \`end\` field-char triple per field.

This PR adds the missing ergonomic layer and includes the page-numbering field helpers callers always end up reinventing.

## API

\`\`\`rust
use docx_rust::{
    document::{num_pages_field, page_field, Footer, Header, Paragraph, Run},
    Docx,
};

let mut docx = Docx::default();

let mut header = Header::default();
header.push(Paragraph::default().push(Run::default().push_text(\"Confidential\")));
docx.add_header(header);

let mut footer = Footer::default();
footer.push(
    Paragraph::default()
        .push(Run::default().push_text(\"Workbench Export\"))
        .push(Run::default().push_tab())
        .push(Run::default().push_text(\"Page \"))
        .push(page_field())
        .push(Run::default().push_text(\" of \"))
        .push(num_pages_field()),
);
docx.add_footer(footer);
\`\`\`

## What's added

- **\`Docx::add_header\` / \`Docx::add_footer\`** + \`_with_type\` variants accepting \`HeaderFooterReferenceType::{Default, Even, First}\`. Each helper allocates the next \`headerN.xml\` / \`footerN.xml\` slot, registers the relationship, adds the matching \`<Override>\` Content Types entry, and attaches a \`HeaderReference\` / \`FooterReference\` to the trailing \`<w:sectPr>\` (creating one if absent).
- **\`Body::last_section_property_mut_or_create\`** — returns the trailing \`<w:sectPr>\`, creating an empty one if the body has none. Backs the section-reference attach in the helpers above.
- **\`document::page_field\`** — \`page_field()\`, \`num_pages_field()\`, \`field_run(instr)\`. Each returns a \`Run\` containing the begin / instrText / end \`FieldChar\` sequence with \`xml:space=\"preserve\"\` so leading and trailing spaces survive.
- **\`Run::push_tab\`** — convenience for the right-aligned-tab pattern used to split a header or footer into left and right halves.

## Bug fix

\`src/docx.rs\` had two locations (sync write at line 145, async write at line 384) where the footer write loop used \`SCHEMA_HEADER\` for the footer relationship. Replaced with \`SCHEMA_FOOTER\`. The new \`add_footer\` helper pre-adds the correct rel and the dedup-by-target check in \`add_rel\` masks the old behaviour for callers using the helper, but bare \`HashMap\` inserts hit the bug.

## What this PR does *not* do

- No header / footer parsing changes — round-trip behaviour is untouched.
- No header-image support. The image PR (#55) and this one compose, but inserting an image into a header is a separate ergonomic question.
- No fancy field switches like \`{ PAGE \\* ROMAN }\`. Use \`field_run(\" PAGE \\* ROMAN \")\` for that.
- No multi-section documents. The helpers attach to the *last* \`<w:sectPr>\`; multi-section authoring is a downstream concern.

## Tests

Seven new tests in \`tests/header_footer_test.rs\`:

1. \`add_footer\` writes the part, the relationship, the Content Types Override, and the \`<w:footerReference>\`.
2. The footer XML contains both \`PAGE\` and \`NUMPAGES\` field codes with \`xml:space=\"preserve\"\`.
3. \`add_header\` writes the part, the relationship, the Content Types Override, and the \`<w:headerReference>\`.
4. Header and footer can coexist in one section with distinct \`rId\`s.
5. \`add_footer_with_type(HeaderFooterReferenceType::First)\` emits \`w:type=\"first\"\`.
6. Two footers in one document get \`footer1.xml\` and \`footer2.xml\` slots.
7. \`Run::push_tab\` emits \`<w:tab/>\`.

\`examples/header_footer.rs\` walks through a 40-paragraph document with a header and a \`Page X of Y\` footer.

All existing tests still pass.