### PR TITLE
feat(svg): add SVG embedding with PNG fallback (asvg:svgBlip)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures-io = { version = "0.3.31" , optional = true}
 
 [dev-dependencies]
 env_logger = "0.11.3"
+png = "0.17"
 tokio = { version = "1.43.0" , features = ["macros", "rt", "fs", "io-util"]}
 tokio-util = { version = "0.7.13", features = ["compat"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ zip = {version = "4", default-features = false, features = ["deflate"]}
 thiserror = "1"
 async_zip = { version = "0.0.17", default-features = false, features = ["deflate"], optional = true }
 futures-io = { version = "0.3.31" , optional = true}
+resvg = { version = "0.45", default-features = false, optional = true }
+tiny-skia = { version = "0.11", optional = true }
+usvg = { version = "0.45", default-features = false, optional = true }
 
 [dev-dependencies]
 env_logger = "0.11.3"
@@ -28,3 +31,4 @@ tokio-util = { version = "0.7.13", features = ["compat"] }
 
 [features]
 async = ["dep:async_zip", "dep:futures-io"]
+svg-rasterize = ["dep:resvg", "dep:tiny-skia", "dep:usvg"]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,52 @@ escape hatch for arbitrary field instructions.
 See [`examples/header_footer.rs`](./examples/header_footer.rs) for an
 end-to-end run.
 
+## SVG with raster fallback
+
+Word 2016+ renders embedded SVG vectorially via the `asvg:svgBlip`
+extension on the standard `<a:blip>`. Older Word ignores the extension
+and falls back to the raster image. Both companion files live in
+`word/media/`, both get relationships, both extensions are registered
+in `[Content_Types].xml`.
+
+```rust
+use docx_rust::{Docx, document::{Paragraph, Run}, media::Pic};
+use std::fs;
+
+let svg = fs::read("logo.svg").unwrap();
+let png = fs::read("logo.png").unwrap();   // pre-rasterised fallback
+
+let mut docx = Docx::default();
+let ids = docx.add_svg("logo", &svg, &png);
+let drawing = Pic::with_svg(ids).size_px(120, 60).into_drawing();
+
+let para = Paragraph::default()
+    .push(Run::default().push_image(drawing));
+docx.document.push(para);
+docx.write_file("with-svg.docx").unwrap();
+```
+
+The default build does not bundle an SVG rasteriser — callers supply
+the PNG fallback themselves. For one-call convenience, enable the
+opt-in `svg-rasterize` feature, which pulls in `resvg` + `usvg` +
+`tiny-skia`:
+
+```toml
+[dependencies]
+docx-rust = { version = "0.2", features = ["svg-rasterize"] }
+```
+
+```rust
+use docx_rust::media::{rasterize_svg, Pic};
+
+let svg = std::fs::read("logo.svg")?;
+let png = rasterize_svg(&svg, 240, 120)?;   // 2x display size for crispness
+let ids = docx.add_svg("logo", &svg, &png);
+```
+
+See [`examples/svg.rs`](./examples/svg.rs) (caller-supplied) and
+[`examples/svg_auto.rs`](./examples/svg_auto.rs) (feature-gated).
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -10,6 +10,32 @@ fork of https://github.com/PoiScript/docx-rs
 
 [Document](https://docs.rs/docx-rust)
 
+## Embedding inline images
+
+```rust
+use docx_rust::{Docx, document::{Paragraph, Run}, media::{MediaType, Pic}};
+use std::fs;
+
+let png = fs::read("logo.png").unwrap();
+
+let mut docx = Docx::default();
+let rid = docx.add_image("logo.png", MediaType::Image, &png);
+let drawing = Pic::new(rid).size_px(120, 60).into_drawing();
+
+let para = Paragraph::default()
+    .push(Run::default().push_image(drawing));
+docx.document.push(para);
+
+docx.write_file("with-logo.docx").unwrap();
+```
+
+`Docx::add_image` registers the bytes, allocates a relationship id,
+and auto-adds the matching `<Default>` Content Types entry (PNG, JPEG,
+BMP, GIF, TIFF). `Pic` produces the `wp:inline` drawing chain. Use
+`size_px` for 96-DPI pixel sizing or `size_emu` for direct EMU.
+
+See [`examples/image.rs`](./examples/image.rs) for an end-to-end run.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -36,6 +36,51 @@ BMP, GIF, TIFF). `Pic` produces the `wp:inline` drawing chain. Use
 
 See [`examples/image.rs`](./examples/image.rs) for an end-to-end run.
 
+## Headers, footers, and page-number fields
+
+```rust
+use docx_rust::{
+    document::{num_pages_field, page_field, Footer, Header, Paragraph, Run},
+    Docx,
+};
+
+let mut docx = Docx::default();
+
+let mut header = Header::default();
+header.push(Paragraph::default().push(Run::default().push_text("Confidential")));
+docx.add_header(header);
+
+let mut footer = Footer::default();
+footer.push(
+    Paragraph::default()
+        .push(Run::default().push_text("Workbench Export"))
+        .push(Run::default().push_tab())
+        .push(Run::default().push_text("Page "))
+        .push(page_field())
+        .push(Run::default().push_text(" of "))
+        .push(num_pages_field()),
+);
+docx.add_footer(footer);
+
+docx.write_file("with-header-and-footer.docx").unwrap();
+```
+
+`Docx::add_header` / `Docx::add_footer` allocate the next `headerN.xml` /
+`footerN.xml` slot, register the relationship, add the matching
+`<Override>` Content Types entry, and attach a `<w:headerReference>` /
+`<w:footerReference>` to the trailing `<w:sectPr>` (creating one if
+absent). The `_with_type` variants take a
+`HeaderFooterReferenceType::{Default, Even, First}` for first-page-only
+or even-page variants.
+
+`page_field()` and `num_pages_field()` return runs containing the
+`{ PAGE }` and `{ NUMPAGES }` field codes respectively. Word
+substitutes the live values at render time. `field_run(instr)` is the
+escape hatch for arbitrary field instructions.
+
+See [`examples/header_footer.rs`](./examples/header_footer.rs) for an
+end-to-end run.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -117,11 +117,15 @@ docx-rust = { version = "0.2", features = ["svg-rasterize"] }
 ```
 
 ```rust
+use docx_rust::Docx;
 use docx_rust::media::{rasterize_svg, Pic};
 
 let svg = std::fs::read("logo.svg")?;
 let png = rasterize_svg(&svg, 240, 120)?;   // 2x display size for crispness
+
+let mut docx = Docx::default();
 let ids = docx.add_svg("logo", &svg, &png);
+let drawing = Pic::with_svg(ids).size_px(120, 60).into_drawing();
 ```
 
 See [`examples/svg.rs`](./examples/svg.rs) (caller-supplied) and

--- a/examples/header_footer.rs
+++ b/examples/header_footer.rs
@@ -1,0 +1,52 @@
+//! Build a document with a header AND a footer that includes the
+//! `Page X of Y` field codes.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example header_footer
+//! ```
+//!
+//! Open `header_footer.docx` in Word. The header should read
+//! "Confidential — Workbench Export" on every page; the footer
+//! should show the doc title on the left and "Page <n> of <total>"
+//! on the right.
+
+use docx_rust::{
+    document::{
+        num_pages_field, page_field, Footer, Header, Paragraph, Run,
+    },
+    Docx, DocxResult,
+};
+
+fn main() -> DocxResult<()> {
+    let mut docx = Docx::default();
+
+    for i in 1..=40 {
+        let para = Paragraph::default()
+            .push(Run::default().push_text(format!("Body paragraph {}.", i)));
+        docx.document.push(para);
+    }
+
+    let mut header = Header::default();
+    header.push(
+        Paragraph::default()
+            .push(Run::default().push_text("Confidential — Workbench Export")),
+    );
+    docx.add_header(header);
+
+    let mut footer = Footer::default();
+    footer.push(
+        Paragraph::default()
+            .push(Run::default().push_text("ImageRight Workbench Export"))
+            .push(Run::default().push_tab())
+            .push(Run::default().push_text("Page "))
+            .push(page_field())
+            .push(Run::default().push_text(" of "))
+            .push(num_pages_field()),
+    );
+    docx.add_footer(footer);
+
+    docx.write_file("header_footer.docx")?;
+    Ok(())
+}

--- a/examples/header_footer.rs
+++ b/examples/header_footer.rs
@@ -9,8 +9,8 @@
 //!
 //! Open `header_footer.docx` in Word. The header should read
 //! "Confidential — Workbench Export" on every page; the footer
-//! should show the doc title on the left and "Page <n> of <total>"
-//! on the right.
+//! should show "ImageRight Workbench Export" on the left and
+//! "Page <n> of <total>" on the right.
 
 use docx_rust::{
     document::{num_pages_field, page_field, Footer, Header, Paragraph, Run},

--- a/examples/header_footer.rs
+++ b/examples/header_footer.rs
@@ -13,9 +13,7 @@
 //! on the right.
 
 use docx_rust::{
-    document::{
-        num_pages_field, page_field, Footer, Header, Paragraph, Run,
-    },
+    document::{num_pages_field, page_field, Footer, Header, Paragraph, Run},
     Docx, DocxResult,
 };
 
@@ -23,15 +21,14 @@ fn main() -> DocxResult<()> {
     let mut docx = Docx::default();
 
     for i in 1..=40 {
-        let para = Paragraph::default()
-            .push(Run::default().push_text(format!("Body paragraph {}.", i)));
+        let para =
+            Paragraph::default().push(Run::default().push_text(format!("Body paragraph {}.", i)));
         docx.document.push(para);
     }
 
     let mut header = Header::default();
     header.push(
-        Paragraph::default()
-            .push(Run::default().push_text("Confidential — Workbench Export")),
+        Paragraph::default().push(Run::default().push_text("Confidential — Workbench Export")),
     );
     docx.add_header(header);
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,0 +1,41 @@
+//! Embed an inline PNG into a docx.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example image
+//! ```
+//!
+//! Output: `image.docx` in the working directory. Open in Word and
+//! the picture should appear inline with the surrounding text.
+
+use docx_rust::{
+    document::{Paragraph, Run},
+    media::{MediaType, Pic},
+    Docx, DocxResult,
+};
+
+/// 1x1 transparent PNG, the smallest valid bytes that decode in Word.
+const TINY_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0x0F, 0x04, 0x00,
+    0x00, 0x09, 0xFB, 0x03, 0xFD, 0x8E, 0xB8, 0x8C, 0x7E, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+fn main() -> DocxResult<()> {
+    let png = TINY_PNG.to_vec();
+
+    let mut docx = Docx::default();
+    let rid = docx.add_image("dot.png", MediaType::Image, &png);
+    let drawing = Pic::new(rid).name("dot").size_px(32, 32).into_drawing();
+
+    let para = Paragraph::default()
+        .push(Run::default().push_text("Behold a tiny dot: "))
+        .push(Run::default().push_image(drawing));
+    docx.document.push(para);
+
+    docx.write_file("image.docx")?;
+    Ok(())
+}

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,13 +1,15 @@
-//! Embed an inline PNG into a docx.
+//! Embed a visible inline PNG into a docx.
+//!
+//! Generates a 32x32 solid red square at runtime using the `png`
+//! dev-dependency, embeds it via the new ergonomic API, and writes
+//! `image.docx` in the working directory. Open in Word: a red square
+//! should appear inline with the surrounding text.
 //!
 //! Run with:
 //!
 //! ```sh
 //! cargo run --example image
 //! ```
-//!
-//! Output: `image.docx` in the working directory. Open in Word and
-//! the picture should appear inline with the surrounding text.
 
 use docx_rust::{
     document::{Paragraph, Run},
@@ -15,24 +17,30 @@ use docx_rust::{
     Docx, DocxResult,
 };
 
-/// 1x1 transparent PNG, the smallest valid bytes that decode in Word.
-const TINY_PNG: &[u8] = &[
-    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
-    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
-    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0x0F, 0x04, 0x00,
-    0x00, 0x09, 0xFB, 0x03, 0xFD, 0x8E, 0xB8, 0x8C, 0x7E, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
-    0x44, 0xAE, 0x42, 0x60, 0x82,
-];
+fn red_square_png(side: u32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut buf, side, side);
+        encoder.set_color(png::ColorType::Rgb);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().expect("png header");
+        let pixels: Vec<u8> = (0..side * side)
+            .flat_map(|_| [0xCC_u8, 0x22, 0x22])
+            .collect();
+        writer.write_image_data(&pixels).expect("png pixels");
+    }
+    buf
+}
 
 fn main() -> DocxResult<()> {
-    let png = TINY_PNG.to_vec();
+    let png = red_square_png(32);
 
     let mut docx = Docx::default();
-    let rid = docx.add_image("dot.png", MediaType::Image, &png);
-    let drawing = Pic::new(rid).name("dot").size_px(32, 32).into_drawing();
+    let rid = docx.add_image("square.png", MediaType::Image, &png);
+    let drawing = Pic::new(rid).name("square").size_px(32, 32).into_drawing();
 
     let para = Paragraph::default()
-        .push(Run::default().push_text("Behold a tiny dot: "))
+        .push(Run::default().push_text("Behold a red square: "))
         .push(Run::default().push_image(drawing));
     docx.document.push(para);
 

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -1,0 +1,57 @@
+//! Embed an SVG in a docx with a caller-supplied PNG raster fallback.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example svg
+//! ```
+//!
+//! Output: `svg.docx` in the working directory. Open in Word 2019+ /
+//! Microsoft 365 — the red circle should render as crisp vector
+//! graphics. Open in Word 2013 — the same circle renders from the
+//! PNG fallback (slightly blurry at very large zoom).
+
+use docx_rust::{
+    document::{Paragraph, Run},
+    media::Pic,
+    Docx, DocxResult,
+};
+
+const SVG: &[u8] =
+    br#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="45" fill="crimson"/><text x="50" y="58" font-size="32" text-anchor="middle" fill="white" font-family="sans-serif">SVG</text></svg>"#;
+
+/// Encode a `side x side` solid-color RGB PNG to use as a raster
+/// fallback. In a real app the fallback would typically be a
+/// rasterised version of the SVG itself.
+fn solid_png(side: u32, rgb: [u8; 3]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut buf, side, side);
+        encoder.set_color(png::ColorType::Rgb);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().expect("png header");
+        let pixels: Vec<u8> = (0..side * side).flat_map(|_| rgb).collect();
+        writer.write_image_data(&pixels).expect("png pixels");
+    }
+    buf
+}
+
+fn main() -> DocxResult<()> {
+    let svg = SVG.to_vec();
+    let png = solid_png(96, [0xDC, 0x14, 0x3C]); // crimson placeholder
+
+    let mut docx = Docx::default();
+    let ids = docx.add_svg("logo", &svg, &png);
+    let drawing = Pic::with_svg(ids)
+        .name("logo")
+        .size_px(96, 96)
+        .into_drawing();
+
+    let para = Paragraph::default()
+        .push(Run::default().push_text("SVG with raster fallback: "))
+        .push(Run::default().push_image(drawing));
+    docx.document.push(para);
+
+    docx.write_file("svg.docx")?;
+    Ok(())
+}

--- a/examples/svg_auto.rs
+++ b/examples/svg_auto.rs
@@ -1,0 +1,49 @@
+//! Embed an SVG in a docx with an auto-rasterised PNG fallback,
+//! using the opt-in `svg-rasterize` cargo feature.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example svg_auto --features svg-rasterize
+//! ```
+//!
+//! Without the feature this example is a no-op stub that prints a
+//! helpful message — keeping the default-feature build honest about
+//! what's available.
+
+#[cfg(feature = "svg-rasterize")]
+fn main() -> docx_rust::DocxResult<()> {
+    use docx_rust::{
+        document::{Paragraph, Run},
+        media::{rasterize_svg, Pic},
+        Docx,
+    };
+
+    const SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="steelblue"/><circle cx="50" cy="50" r="30" fill="white"/></svg>"#;
+
+    let svg = SVG.to_vec();
+    let png = rasterize_svg(&svg, 192, 192).expect("rasterise SVG");
+
+    let mut docx = Docx::default();
+    let ids = docx.add_svg("logo", &svg, &png);
+    let drawing = Pic::with_svg(ids)
+        .name("logo")
+        .size_px(96, 96)
+        .into_drawing();
+
+    let para = Paragraph::default()
+        .push(Run::default().push_text("Auto-rasterised SVG: "))
+        .push(Run::default().push_image(drawing));
+    docx.document.push(para);
+
+    docx.write_file("svg_auto.docx")?;
+    Ok(())
+}
+
+#[cfg(not(feature = "svg-rasterize"))]
+fn main() {
+    eprintln!(
+        "This example requires the `svg-rasterize` cargo feature. \
+         Run again with: `cargo run --example svg_auto --features svg-rasterize`."
+    );
+}

--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -36,10 +36,7 @@ impl<'a> Body<'a> {
     /// guaranteed without forcing every caller to walk the content
     /// vector.
     pub fn last_section_property_mut_or_create(&mut self) -> &mut SectionProperty<'a> {
-        let last_is_sect_pr = matches!(
-            self.content.last(),
-            Some(BodyContent::SectionProperty(_))
-        );
+        let last_is_sect_pr = matches!(self.content.last(), Some(BodyContent::SectionProperty(_)));
         if !last_is_sect_pr {
             self.content
                 .push(BodyContent::SectionProperty(SectionProperty::default()));

--- a/src/document/body.rs
+++ b/src/document/body.rs
@@ -26,6 +26,30 @@ impl<'a> Body<'a> {
         self
     }
 
+    /// Return the trailing `<w:sectPr>` of this body, creating an
+    /// empty one if absent.
+    ///
+    /// Headers and footers are wired into a section via
+    /// `<w:headerReference>` / `<w:footerReference>` children of a
+    /// `<w:sectPr>`. A well-formed document has exactly one section
+    /// property at the end of the body; this helper makes that
+    /// guaranteed without forcing every caller to walk the content
+    /// vector.
+    pub fn last_section_property_mut_or_create(&mut self) -> &mut SectionProperty<'a> {
+        let last_is_sect_pr = matches!(
+            self.content.last(),
+            Some(BodyContent::SectionProperty(_))
+        );
+        if !last_is_sect_pr {
+            self.content
+                .push(BodyContent::SectionProperty(SectionProperty::default()));
+        }
+        match self.content.last_mut() {
+            Some(BodyContent::SectionProperty(sp)) => sp,
+            _ => unreachable!("just pushed or matched a SectionProperty"),
+        }
+    }
+
     pub fn text(&self) -> String {
         let v: Vec<_> = self
             .content

--- a/src/document/drawing.rs
+++ b/src/document/drawing.rs
@@ -396,6 +396,46 @@ pub struct Blip<'a> {
     pub embed: Cow<'a, str>,
     #[xml(default, attr = "cstate")]
     pub cstate: Option<Cow<'a, str>>,
+    #[xml(child = "a:extLst")]
+    pub ext_lst: Option<BlipExtList<'a>>,
+}
+
+/// `<a:extLst>` — extension list inside an `<a:blip>`. Currently used
+/// by this crate to carry the Office 2016+ `asvg:svgBlip` element so
+/// modern Word renders an SVG companion to the raster fallback.
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "a:extLst")]
+pub struct BlipExtList<'a> {
+    #[xml(child = "a:ext")]
+    pub exts: Vec<BlipExt<'a>>,
+}
+
+/// `<a:ext uri="...">` — a single extension entry. The URI identifies
+/// the extension; readers that recognise it consume the children,
+/// readers that don't ignore the whole element. See
+/// [`crate::schema::SVG_BLIP_EXT_URI`] for the SVG-specific value.
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "a:ext")]
+pub struct BlipExt<'a> {
+    #[xml(default, attr = "uri")]
+    pub uri: Cow<'a, str>,
+    #[xml(child = "asvg:svgBlip")]
+    pub svg_blip: Option<SvgBlip<'a>>,
+}
+
+/// `<asvg:svgBlip>` — Office 2016+ extension pointing at the SVG bytes.
+/// Modern Word renders this; legacy Word ignores it and falls back to
+/// the standard `<a:blip>` PNG.
+#[derive(Debug, Default, XmlRead, XmlWrite, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+#[xml(tag = "asvg:svgBlip")]
+pub struct SvgBlip<'a> {
+    #[xml(default, attr = "xmlns:asvg")]
+    pub xmlns_asvg: Cow<'a, str>,
+    #[xml(default, attr = "r:embed")]
+    pub embed: Cow<'a, str>,
 }
 
 #[derive(Debug, Default, XmlRead, XmlWrite, Clone)]

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -18,6 +18,7 @@ mod header_footer_reference;
 mod hyperlink;
 mod instrtext;
 mod numbering;
+mod page_field;
 mod paragraph;
 mod run;
 mod sdt;
@@ -33,6 +34,7 @@ mod theme;
 pub use self::{
     body::*, bookmark_end::*, bookmark_start::*, comment_range::*, comments::*, document::*,
     drawing::*, endnotes::*, field_char::*, footer::*, footnotes::*, grid_column::*, header::*,
-    header_footer_reference::*, hyperlink::*, numbering::*, paragraph::*, r#break::*, run::*,
-    sdt::*, tab::*, table::*, table_cell::*, table_grid::*, table_row::*, text::*, theme::*,
+    header_footer_reference::*, hyperlink::*, numbering::*, page_field::*, paragraph::*,
+    r#break::*, run::*, sdt::*, tab::*, table::*, table_cell::*, table_grid::*, table_row::*,
+    text::*, theme::*,
 };

--- a/src/document/page_field.rs
+++ b/src/document/page_field.rs
@@ -1,0 +1,62 @@
+//! Field-code helpers for page numbering in headers and footers.
+//!
+//! Word represents a simple field like `{ PAGE }` as a sequence of
+//! three run-content elements:
+//!
+//! 1. `<w:fldChar w:fldCharType="begin"/>`
+//! 2. `<w:instrText> PAGE </w:instrText>`
+//! 3. `<w:fldChar w:fldCharType="end"/>`
+//!
+//! These helpers build a single [`Run`] containing that sequence,
+//! ready to push into a [`Paragraph`](crate::document::Paragraph). Word
+//! recomputes the displayed value on open or when the user presses F9.
+//!
+//! ```rust
+//! use docx_rust::document::{Paragraph, Run, page_field, num_pages_field};
+//!
+//! let footer_para = Paragraph::default()
+//!     .push(Run::default().push_text("Page "))
+//!     .push(page_field())
+//!     .push(Run::default().push_text(" of "))
+//!     .push(num_pages_field());
+//! ```
+
+use std::borrow::Cow;
+
+use crate::document::{
+    field_char::{CharType, FieldChar},
+    instrtext::{InstrText, TextSpace},
+    Run, RunContent,
+};
+
+/// A run containing a `{ PAGE }` field. Word substitutes the current
+/// page number at render time.
+pub fn page_field<'a>() -> Run<'a> {
+    field_run(" PAGE ")
+}
+
+/// A run containing a `{ NUMPAGES }` field. Word substitutes the
+/// total page count at render time.
+pub fn num_pages_field<'a>() -> Run<'a> {
+    field_run(" NUMPAGES ")
+}
+
+/// Build a run holding an arbitrary simple Word field. The provided
+/// instruction string is wrapped in `begin`/`end` field-char markers
+/// with `xml:space="preserve"` so leading and trailing spaces survive.
+///
+/// Use [`page_field`] / [`num_pages_field`] for the common cases.
+pub fn field_run<'a>(instr: impl Into<Cow<'a, str>>) -> Run<'a> {
+    let mut run = Run::default();
+    run.content.push(RunContent::FieldChar(FieldChar {
+        ty: Some(CharType::Begin),
+    }));
+    run.content.push(RunContent::InstrText(InstrText {
+        space: Some(TextSpace::Preserve),
+        text: instr.into(),
+    }));
+    run.content.push(RunContent::FieldChar(FieldChar {
+        ty: Some(CharType::End),
+    }));
+    run
+}

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -4,13 +4,13 @@ use hard_xml::{XmlRead, XmlWrite};
 use std::borrow::{Borrow, Cow};
 
 use crate::{
-    __setter, __xml_test_suites,
+    __define_enum, __define_struct, __setter, __xml_test_suites,
     document::{
         drawing::Drawing, field_char::FieldChar, instrtext::InstrText, r#break::Break,
         r#break::LastRenderedPageBreak, tab::Tab, text::Text,
     },
     formatting::CharacterProperty,
-    DocxResult, __define_enum, __define_struct,
+    DocxResult,
 };
 
 use super::{

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -116,6 +116,15 @@ impl<'a> Run<'a> {
         self
     }
 
+    /// Append a `<w:tab/>` tab character. Useful for splitting a
+    /// header or footer paragraph into left- and right-aligned
+    /// halves via the section's default tab stops.
+    #[inline(always)]
+    pub fn push_tab(mut self) -> Self {
+        self.content.push(RunContent::Tab(Tab));
+        self
+    }
+
     pub fn text(&self) -> String {
         self.iter_text()
             .map(|c| c.to_string())

--- a/src/document/run.rs
+++ b/src/document/run.rs
@@ -108,6 +108,14 @@ impl<'a> Run<'a> {
         self
     }
 
+    /// Append an inline drawing (typically built via
+    /// [`Pic::into_drawing`](crate::media::Pic::into_drawing)).
+    #[inline(always)]
+    pub fn push_image(mut self, drawing: Drawing<'a>) -> Self {
+        self.content.push(RunContent::Drawing(drawing));
+        self
+    }
+
     pub fn text(&self) -> String {
         self.iter_text()
             .map(|c| c.to_string())

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -11,11 +11,14 @@ use std::path::Path;
 use zip::write::SimpleFileOptions;
 use zip::{result::ZipError, CompressionMethod, ZipArchive, ZipWriter};
 
-use crate::document::{Comments, EndNotes, FootNotes, Footer, Header, Numbering, Theme};
+use crate::document::{
+    Comments, EndNotes, FootNotes, Footer, FooterReference, Header, HeaderFooterReference,
+    HeaderFooterReferenceType, HeaderReference, Numbering, Theme,
+};
 use crate::media::MediaType;
 use crate::schema::{
-    SCHEMA_COMMENTS, SCHEMA_ENDNOTES, SCHEMA_FOOTNOTES, SCHEMA_HEADER, SCHEMA_NUMBERING,
-    SCHEMA_SETTINGS, SCHEMA_THEME, SCHEMA_WEB_SETTINGS,
+    SCHEMA_COMMENTS, SCHEMA_ENDNOTES, SCHEMA_FOOTER, SCHEMA_FOOTNOTES, SCHEMA_HEADER,
+    SCHEMA_NUMBERING, SCHEMA_SETTINGS, SCHEMA_THEME, SCHEMA_WEB_SETTINGS,
 };
 use crate::settings::Settings;
 use crate::web_settings::WebSettings;
@@ -142,7 +145,7 @@ impl<'a> Docx<'a> {
         for ft in &self.footers {
             self.document_rels
                 .get_or_insert(Relationships::default())
-                .add_rel(SCHEMA_HEADER, ft.0);
+                .add_rel(SCHEMA_FOOTER, ft.0);
         }
 
         for theme in &self.themes {
@@ -292,6 +295,123 @@ impl<'a> Docx<'a> {
             .add_rel_returning_id(Cow::Borrowed(schema), path)
     }
 
+    /// Register a footer with the default reference type
+    /// (`HeaderFooterReferenceType::Default` — applies to every page).
+    ///
+    /// See [`Docx::add_footer_with_type`] for first-page-only or
+    /// even-page variants.
+    pub fn add_footer(&mut self, footer: Footer<'a>) -> String {
+        self.add_footer_with_type(footer, HeaderFooterReferenceType::Default)
+    }
+
+    /// Register a footer for a specific reference type.
+    ///
+    /// Auto-handles:
+    ///
+    /// * allocating the next `footerN.xml` slot in `self.footers`
+    /// * adding the relationship to `self.document_rels`
+    /// * registering the `Override` Content Types entry
+    /// * attaching a `<w:footerReference>` to the trailing
+    ///   `<w:sectPr>` of the body, creating one if necessary
+    ///
+    /// Returns the relationship id (`"rId12"` etc.).
+    pub fn add_footer_with_type(
+        &mut self,
+        footer: Footer<'a>,
+        ty: HeaderFooterReferenceType,
+    ) -> String {
+        let n = (1u32..)
+            .find(|i| !self.footers.contains_key(&format!("footer{}.xml", i)))
+            .expect("u32 range exhausted");
+        let part = format!("footer{}.xml", n);
+
+        self.footers.insert(part.clone(), footer);
+
+        let rid = self
+            .document_rels
+            .get_or_insert_with(Relationships::default)
+            .add_rel_returning_id(Cow::Borrowed(SCHEMA_FOOTER), part.clone());
+
+        self.ensure_part_override(
+            &format!("/word/{}", part),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml",
+        );
+
+        let reference = FooterReference {
+            ty: Some(ty),
+            id: Some(Cow::Owned(rid.clone())),
+        };
+        self.document
+            .body
+            .last_section_property_mut_or_create()
+            .header_footer_references
+            .push(HeaderFooterReference::Footer(reference));
+
+        rid
+    }
+
+    /// Register a header with the default reference type
+    /// (`HeaderFooterReferenceType::Default` — applies to every page).
+    ///
+    /// See [`Docx::add_header_with_type`] for first-page-only or
+    /// even-page variants.
+    pub fn add_header(&mut self, header: Header<'a>) -> String {
+        self.add_header_with_type(header, HeaderFooterReferenceType::Default)
+    }
+
+    /// Register a header for a specific reference type. Symmetric with
+    /// [`Docx::add_footer_with_type`].
+    pub fn add_header_with_type(
+        &mut self,
+        header: Header<'a>,
+        ty: HeaderFooterReferenceType,
+    ) -> String {
+        let n = (1u32..)
+            .find(|i| !self.headers.contains_key(&format!("header{}.xml", i)))
+            .expect("u32 range exhausted");
+        let part = format!("header{}.xml", n);
+
+        self.headers.insert(part.clone(), header);
+
+        let rid = self
+            .document_rels
+            .get_or_insert_with(Relationships::default)
+            .add_rel_returning_id(Cow::Borrowed(SCHEMA_HEADER), part.clone());
+
+        self.ensure_part_override(
+            &format!("/word/{}", part),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml",
+        );
+
+        let reference = HeaderReference {
+            ty: Some(ty),
+            id: Some(Cow::Owned(rid.clone())),
+        };
+        self.document
+            .body
+            .last_section_property_mut_or_create()
+            .header_footer_references
+            .push(HeaderFooterReference::Header(reference));
+
+        rid
+    }
+
+    fn ensure_part_override(&mut self, partname: &str, content_type: &'static str) {
+        let already = self
+            .content_types
+            .overrides
+            .iter()
+            .any(|o| o.part == partname);
+        if !already {
+            self.content_types
+                .overrides
+                .push(crate::content_type::OverrideContentType {
+                    part: Cow::Owned(partname.to_string()),
+                    ty: Cow::Borrowed(content_type),
+                });
+        }
+    }
+
     fn ensure_image_content_type(&mut self, ext: &str) {
         let mime = match ext {
             "png" => "image/png",
@@ -393,7 +513,7 @@ impl<'a> Docx<'a> {
         for ft in &self.footers {
             self.document_rels
                 .get_or_insert(Relationships::default())
-                .add_rel(SCHEMA_HEADER, ft.0);
+                .add_rel(SCHEMA_FOOTER, ft.0);
         }
 
         for theme in &self.themes {

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -56,7 +56,7 @@ pub struct Docx<'a> {
     pub headers: HashMap<String, Header<'a>>,
     pub footers: HashMap<String, Footer<'a>>,
     pub themes: HashMap<String, Theme<'a>>,
-    pub media: HashMap<String, (MediaType, &'a Vec<u8>)>,
+    pub media: HashMap<String, (MediaType, &'a [u8])>,
     pub footnotes: Option<FootNotes<'a>>,
     pub endnotes: Option<EndNotes<'a>>,
     pub settings: Option<Settings<'a>>,
@@ -256,13 +256,27 @@ impl<'a> Docx<'a> {
     /// generated `.docx` opens as "corrupt" in Word.
     ///
     /// The image bytes are borrowed for the lifetime of the `Docx`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `filename` is not a leaf name (contains `/`, `\\`,
+    /// or `..`). This guards against zip-path traversal: a caller
+    /// passing `"../_rels/document.xml.rels"` would otherwise
+    /// overwrite an internal package part. Pass only the file's
+    /// basename — the helper places it under `word/media/` itself.
     pub fn add_image(
         &mut self,
         filename: impl Into<Cow<'a, str>>,
         media_type: MediaType,
-        bytes: &'a Vec<u8>,
+        bytes: &'a [u8],
     ) -> String {
         let filename = filename.into();
+        if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+            panic!(
+                "add_image filename must be a leaf name with no path separators or '..': {:?}",
+                filename
+            );
+        }
         let path = format!("media/{}", filename);
 
         if let Some(ext) = filename.rsplit('.').next() {
@@ -642,7 +656,7 @@ impl DocxFile {
             let mt = crate::media::get_media_type(&m.0);
             if let Some(mt) = mt {
                 let name = m.0.replace("word/", "");
-                let m = (mt, &m.1);
+                let m = (mt, m.1.as_slice());
                 media.insert(name, m);
             }
         }

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -308,8 +308,9 @@ impl<'a> Docx<'a> {
     /// inside the zip. `png_fallback_bytes` are NOT auto-generated —
     /// the caller is responsible for rasterising the SVG at the
     /// desired display resolution. For an opt-in auto-rasterise
-    /// path, enable the `svg-rasterize` cargo feature and use
-    /// [`Docx::add_svg_auto`].
+    /// path, enable the `svg-rasterize` cargo feature and call
+    /// [`crate::media::rasterize_svg`] yourself, then pass its
+    /// output as `png_fallback_bytes`.
     ///
     /// Returns [`crate::media::SvgImageIds`] holding both relationship
     /// ids; pass it to [`crate::media::Pic::with_svg`] to build the

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -313,6 +313,15 @@ impl<'a> Docx<'a> {
     /// * registering the `Override` Content Types entry
     /// * attaching a `<w:footerReference>` to the trailing
     ///   `<w:sectPr>` of the body, creating one if necessary
+    /// * for `First` types, also setting `<w:titlePg/>` on the
+    ///   trailing section properties — Word ignores a
+    ///   `w:type="first"` reference without this flag
+    /// * for `Even` types, also setting `<w:evenAndOddHeaders/>`
+    ///   on `word/settings.xml` — Word ignores a `w:type="even"`
+    ///   reference without this setting
+    /// * if a footer of the same type already exists for this
+    ///   section, the old reference is replaced rather than
+    ///   appended (Word treats duplicates inconsistently)
     ///
     /// Returns the relationship id (`"rId12"` etc.).
     pub fn add_footer_with_type(
@@ -338,14 +347,15 @@ impl<'a> Docx<'a> {
         );
 
         let reference = FooterReference {
-            ty: Some(ty),
+            ty: Some(ty.clone()),
             id: Some(Cow::Owned(rid.clone())),
         };
-        self.document
-            .body
-            .last_section_property_mut_or_create()
-            .header_footer_references
-            .push(HeaderFooterReference::Footer(reference));
+        let sect_pr = self.document.body.last_section_property_mut_or_create();
+        replace_footer_reference_of_type(&mut sect_pr.header_footer_references, &ty, reference);
+        if matches!(ty, HeaderFooterReferenceType::First) {
+            sect_pr.title_page = Some(crate::formatting::TitlePage::default());
+        }
+        self.ensure_settings_for_type(&ty);
 
         rid
     }
@@ -360,7 +370,10 @@ impl<'a> Docx<'a> {
     }
 
     /// Register a header for a specific reference type. Symmetric with
-    /// [`Docx::add_footer_with_type`].
+    /// [`Docx::add_footer_with_type`] — see that method for the full
+    /// list of side-effects (Content Types, rels, section reference,
+    /// `titlePg` for First, `evenAndOddHeaders` for Even, replace
+    /// existing reference of same type rather than append).
     pub fn add_header_with_type(
         &mut self,
         header: Header<'a>,
@@ -384,16 +397,26 @@ impl<'a> Docx<'a> {
         );
 
         let reference = HeaderReference {
-            ty: Some(ty),
+            ty: Some(ty.clone()),
             id: Some(Cow::Owned(rid.clone())),
         };
-        self.document
-            .body
-            .last_section_property_mut_or_create()
-            .header_footer_references
-            .push(HeaderFooterReference::Header(reference));
+        let sect_pr = self.document.body.last_section_property_mut_or_create();
+        replace_header_reference_of_type(&mut sect_pr.header_footer_references, &ty, reference);
+        if matches!(ty, HeaderFooterReferenceType::First) {
+            sect_pr.title_page = Some(crate::formatting::TitlePage::default());
+        }
+        self.ensure_settings_for_type(&ty);
 
         rid
+    }
+
+    fn ensure_settings_for_type(&mut self, ty: &HeaderFooterReferenceType) {
+        if matches!(ty, HeaderFooterReferenceType::Even) {
+            let settings = self.settings.get_or_insert_with(Settings::default);
+            if settings.even_and_odd_headers.is_none() {
+                settings.even_and_odd_headers = Some(crate::settings::EvenAndOddHeaders::default());
+            }
+        }
     }
 
     fn ensure_part_override(&mut self, partname: &str, content_type: &'static str) {
@@ -435,6 +458,47 @@ impl<'a> Docx<'a> {
                     ty: Cow::Borrowed(mime),
                 });
         }
+    }
+}
+
+/// Replace any existing header reference of `ty`, then append the new
+/// one. Header- and footer-references coexist in one Vec discriminated
+/// by enum variant, so the helper only touches Header variants.
+fn replace_header_reference_of_type<'a>(
+    refs: &mut Vec<HeaderFooterReference<'a>>,
+    ty: &HeaderFooterReferenceType,
+    new_ref: HeaderReference<'a>,
+) {
+    refs.retain(|r| match r {
+        HeaderFooterReference::Header(h) => !matches_type(&h.ty, ty),
+        HeaderFooterReference::Footer(_) => true,
+    });
+    refs.push(HeaderFooterReference::Header(new_ref));
+}
+
+/// Footer-side counterpart to [`replace_header_reference_of_type`].
+fn replace_footer_reference_of_type<'a>(
+    refs: &mut Vec<HeaderFooterReference<'a>>,
+    ty: &HeaderFooterReferenceType,
+    new_ref: FooterReference<'a>,
+) {
+    refs.retain(|r| match r {
+        HeaderFooterReference::Footer(f) => !matches_type(&f.ty, ty),
+        HeaderFooterReference::Header(_) => true,
+    });
+    refs.push(HeaderFooterReference::Footer(new_ref));
+}
+
+fn matches_type(
+    found: &Option<HeaderFooterReferenceType>,
+    expected: &HeaderFooterReferenceType,
+) -> bool {
+    use HeaderFooterReferenceType::*;
+    match (found, expected) {
+        (Some(Default), Default) | (None, Default) => true,
+        (Some(First), First) => true,
+        (Some(Even), Even) => true,
+        _ => false,
     }
 }
 

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -295,6 +295,41 @@ impl<'a> Docx<'a> {
             .add_rel_returning_id(Cow::Borrowed(schema), path)
     }
 
+    /// Register an SVG image with a paired raster fallback.
+    ///
+    /// Word 2016+ renders the SVG via the `asvg:svgBlip` extension on
+    /// the `<a:blip>`; older Word ignores the extension and uses the
+    /// raster fallback. Both parts are stored as media in the docx
+    /// zip; both get relationships in `document.xml.rels`; both
+    /// extensions are registered in `[Content_Types].xml`.
+    ///
+    /// `name_stem` is the leaf name without extension (e.g. `"logo"`).
+    /// The helper produces `media/<stem>.svg` and `media/<stem>.png`
+    /// inside the zip. `png_fallback_bytes` are NOT auto-generated —
+    /// the caller is responsible for rasterising the SVG at the
+    /// desired display resolution. For an opt-in auto-rasterise
+    /// path, enable the `svg-rasterize` cargo feature and use
+    /// [`Docx::add_svg_auto`].
+    ///
+    /// Returns [`crate::media::SvgImageIds`] holding both relationship
+    /// ids; pass it to [`crate::media::Pic::with_svg`] to build the
+    /// drawing.
+    pub fn add_svg(
+        &mut self,
+        name_stem: impl Into<Cow<'a, str>>,
+        svg_bytes: &'a Vec<u8>,
+        png_fallback_bytes: &'a Vec<u8>,
+    ) -> crate::media::SvgImageIds {
+        let stem = name_stem.into();
+        let svg_filename = format!("{}.svg", stem);
+        let png_filename = format!("{}.png", stem);
+
+        let png_rid = self.add_image(png_filename, MediaType::Image, png_fallback_bytes);
+        let svg_rid = self.add_image(svg_filename, MediaType::Image, svg_bytes);
+
+        crate::media::SvgImageIds { svg_rid, png_rid }
+    }
+
     /// Register a footer with the default reference type
     /// (`HeaderFooterReferenceType::Default` — applies to every page).
     ///
@@ -442,6 +477,7 @@ impl<'a> Docx<'a> {
             "bmp" => "image/bmp",
             "gif" => "image/gif",
             "tif" | "tiff" => "image/tiff",
+            "svg" => "image/svg+xml",
             _ => return,
         };
 

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -243,6 +243,67 @@ impl<'a> Docx<'a> {
         let file = File::create(path)?;
         self.write(file)
     }
+
+    /// Register an image in the document's media store and return the
+    /// relationship id (e.g. `"rId12"`) that callers pass to
+    /// [`Pic::new`](crate::media::Pic::new).
+    ///
+    /// `filename` is the leaf name (e.g. `"cat.png"`); the helper
+    /// stores it under `media/<filename>` in the resulting zip.
+    ///
+    /// Auto-registers a `<Default>` Content Types entry for the file
+    /// extension if one is not already present. Without this the
+    /// generated `.docx` opens as "corrupt" in Word.
+    ///
+    /// The image bytes are borrowed for the lifetime of the `Docx`.
+    pub fn add_image(
+        &mut self,
+        filename: impl Into<Cow<'a, str>>,
+        media_type: MediaType,
+        bytes: &'a Vec<u8>,
+    ) -> String {
+        let filename = filename.into();
+        let path = format!("media/{}", filename);
+
+        if let Some(ext) = filename.rsplit('.').next() {
+            self.ensure_image_content_type(&ext.to_ascii_lowercase());
+        }
+
+        self.media.insert(path.clone(), (media_type, bytes));
+
+        let schema = crate::media::get_media_type_relation_type(
+            &self.media[&path].0,
+        );
+
+        self.document_rels
+            .get_or_insert_with(Relationships::default)
+            .add_rel_returning_id(Cow::Borrowed(schema), path)
+    }
+
+    fn ensure_image_content_type(&mut self, ext: &str) {
+        let mime = match ext {
+            "png" => "image/png",
+            "jpg" | "jpeg" => "image/jpeg",
+            "bmp" => "image/bmp",
+            "gif" => "image/gif",
+            "tif" | "tiff" => "image/tiff",
+            _ => return,
+        };
+
+        let already = self
+            .content_types
+            .defaults
+            .iter()
+            .any(|d| d.ext.eq_ignore_ascii_case(ext));
+        if !already {
+            self.content_types
+                .defaults
+                .push(crate::content_type::DefaultContentType {
+                    ext: Cow::Owned(ext.to_string()),
+                    ty: Cow::Borrowed(mime),
+                });
+        }
+    }
 }
 
 #[cfg(feature = "async")]

--- a/src/docx.rs
+++ b/src/docx.rs
@@ -271,9 +271,7 @@ impl<'a> Docx<'a> {
 
         self.media.insert(path.clone(), (media_type, bytes));
 
-        let schema = crate::media::get_media_type_relation_type(
-            &self.media[&path].0,
-        );
+        let schema = crate::media::get_media_type_relation_type(&self.media[&path].0);
 
         self.document_rels
             .get_or_insert_with(Relationships::default)

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,7 +1,12 @@
 use crate::schema::SCHEMA_IMAGE;
 
 mod pic;
-pub use pic::{Pic, EMU_PER_INCH, EMU_PER_PIXEL};
+pub use pic::{Pic, SvgImageIds, EMU_PER_INCH, EMU_PER_PIXEL};
+
+#[cfg(feature = "svg-rasterize")]
+mod svg_rasterize;
+#[cfg(feature = "svg-rasterize")]
+pub use svg_rasterize::{rasterize_svg, SvgRasterizeError};
 
 /// Specifies the type of a media file
 ///
@@ -22,6 +27,10 @@ pub fn get_media_type(filename: &str) -> Option<MediaType> {
         | filename.ends_with("jpg")
         | filename.ends_with("jpeg")
         | filename.ends_with("bmp")
+        | filename.ends_with("gif")
+        | filename.ends_with("tif")
+        | filename.ends_with("tiff")
+        | filename.ends_with("svg")
     {
         Some(MediaType::Image)
     } else {

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,5 +1,8 @@
 use crate::schema::SCHEMA_IMAGE;
 
+mod pic;
+pub use pic::{Pic, EMU_PER_INCH, EMU_PER_PIXEL};
+
 /// Specifies the type of a media file
 ///
 #[derive(Debug, Clone)]

--- a/src/media/pic.rs
+++ b/src/media/pic.rs
@@ -1,0 +1,177 @@
+//! Inline picture helper.
+//!
+//! Wraps the tedium of constructing the
+//! `Drawing → Inline → Graphic → Picture → BlipFill → Blip` XML chain
+//! for the common case of placing an image in a run.
+//!
+//! The helper does NOT register image bytes with the document; callers
+//! do that via [`Docx::add_image`](crate::Docx::add_image) to obtain
+//! the relationship id used here.
+//!
+//! ```no_run
+//! use docx_rust::Docx;
+//! use docx_rust::document::{Paragraph, Run};
+//! use docx_rust::media::{MediaType, Pic};
+//!
+//! # let png_bytes: Vec<u8> = vec![];
+//! let mut docx = Docx::default();
+//! let rid = docx.add_image("cat.png", MediaType::Image, &png_bytes);
+//! let drawing = Pic::new(rid).size_px(160, 120).into_drawing();
+//! let para = Paragraph::default()
+//!     .push(Run::default().push_image(drawing));
+//! docx.document.push(para);
+//! ```
+
+use std::borrow::Cow;
+
+use crate::document::{
+    Blip, BlipFill, CNvPicPr, CNvPr, DocPr, Drawing, Ext, Extent, FillRect, Graphic, GraphicData,
+    Inline, NvPicPr, Offset, Picture, PrstGeom, SpPr, Stretch, Xfrm,
+};
+use crate::schema::{SCHEMA_DRAWINGML, SCHEMA_PIC};
+
+/// English Metric Units per pixel at 96 DPI.
+pub const EMU_PER_PIXEL: u64 = 9_525;
+
+/// English Metric Units per inch.
+pub const EMU_PER_INCH: u64 = 914_400;
+
+/// Builder for an inline picture.
+///
+/// Sizes default to 16x16 pixels at 96 DPI; override with
+/// [`Pic::size_px`] or [`Pic::size_emu`].
+pub struct Pic<'a> {
+    rid: Cow<'a, str>,
+    name: Cow<'a, str>,
+    descr: Option<Cow<'a, str>>,
+    width_emu: u64,
+    height_emu: u64,
+    doc_id: isize,
+}
+
+impl<'a> Pic<'a> {
+    /// Create a builder from a relationship id previously returned by
+    /// [`Docx::add_image`](crate::Docx::add_image).
+    pub fn new(rid: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            rid: rid.into(),
+            name: Cow::Borrowed("image"),
+            descr: None,
+            width_emu: 16 * EMU_PER_PIXEL,
+            height_emu: 16 * EMU_PER_PIXEL,
+            doc_id: 1,
+        }
+    }
+
+    /// Set the picture display name (appears in `wp:docPr` / `pic:cNvPr`).
+    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Set the alt-text description.
+    pub fn descr(mut self, descr: impl Into<Cow<'a, str>>) -> Self {
+        self.descr = Some(descr.into());
+        self
+    }
+
+    /// Set size in pixels at 96 DPI. Internally converts to EMU.
+    pub fn size_px(mut self, w: u64, h: u64) -> Self {
+        self.width_emu = w * EMU_PER_PIXEL;
+        self.height_emu = h * EMU_PER_PIXEL;
+        self
+    }
+
+    /// Set size directly in English Metric Units.
+    pub fn size_emu(mut self, w: u64, h: u64) -> Self {
+        self.width_emu = w;
+        self.height_emu = h;
+        self
+    }
+
+    /// Set the document-wide unique picture id. Defaults to 1; bump
+    /// when embedding multiple images in the same document.
+    pub fn doc_id(mut self, id: isize) -> Self {
+        self.doc_id = id;
+        self
+    }
+
+    /// Build the [`Drawing`] ready to push into a [`Run`](crate::document::Run).
+    pub fn into_drawing(self) -> Drawing<'a> {
+        let Pic {
+            rid,
+            name,
+            descr,
+            width_emu,
+            height_emu,
+            doc_id,
+        } = self;
+
+        let cx = width_emu as isize;
+        let cy = height_emu as isize;
+
+        let picture = Picture {
+            a: Cow::Borrowed(SCHEMA_PIC),
+            nv_pic_pr: NvPicPr {
+                c_nv_pr: Some(CNvPr {
+                    id: Some(doc_id),
+                    name: Some(name.clone()),
+                    descr: descr.clone(),
+                }),
+                c_nv_pic_pr: Some(CNvPicPr::default()),
+            },
+            fill: BlipFill {
+                blip: Blip {
+                    embed: rid,
+                    cstate: None,
+                },
+                stretch: Some(Stretch {
+                    fill_rect: Some(FillRect::default()),
+                }),
+            },
+            sp_pr: SpPr {
+                xfrm: Some(Xfrm {
+                    offset: Some(Offset {
+                        x: Some(0),
+                        y: Some(0),
+                    }),
+                    ext: Some(Ext {
+                        cx: Some(cx),
+                        cy: Some(cy),
+                    }),
+                }),
+                prst_geom: Some(PrstGeom {
+                    prst: Some(Cow::Borrowed("rect")),
+                    av_lst: None,
+                }),
+            },
+        };
+
+        let graphic = Graphic {
+            a: Cow::Borrowed(SCHEMA_DRAWINGML),
+            data: GraphicData {
+                uri: Cow::Borrowed(SCHEMA_PIC),
+                children: vec![picture],
+            },
+        };
+
+        let inline = Inline {
+            extent: Some(Extent {
+                cx: width_emu,
+                cy: height_emu,
+            }),
+            doc_property: DocPr {
+                id: Some(doc_id),
+                name: Some(name),
+                descr,
+            },
+            graphic: Some(graphic),
+            ..Inline::default()
+        };
+
+        Drawing {
+            anchor: None,
+            inline: Some(inline),
+        }
+    }
+}

--- a/src/media/pic.rs
+++ b/src/media/pic.rs
@@ -46,7 +46,7 @@ pub struct Pic<'a> {
     descr: Option<Cow<'a, str>>,
     width_emu: u64,
     height_emu: u64,
-    doc_id: isize,
+    doc_id: u32,
 }
 
 impl<'a> Pic<'a> {
@@ -76,9 +76,15 @@ impl<'a> Pic<'a> {
     }
 
     /// Set size in pixels at 96 DPI. Internally converts to EMU.
+    ///
+    /// Saturates at `u64::MAX` if the multiplication overflows, so a
+    /// pathological caller cannot panic the builder. The resulting
+    /// EMU value will exceed Word's max image dimension and the
+    /// document will simply render that picture clamped to the page,
+    /// which is the right failure mode for unrealistic sizes.
     pub fn size_px(mut self, w: u64, h: u64) -> Self {
-        self.width_emu = w * EMU_PER_PIXEL;
-        self.height_emu = h * EMU_PER_PIXEL;
+        self.width_emu = w.saturating_mul(EMU_PER_PIXEL);
+        self.height_emu = h.saturating_mul(EMU_PER_PIXEL);
         self
     }
 
@@ -91,7 +97,10 @@ impl<'a> Pic<'a> {
 
     /// Set the document-wide unique picture id. Defaults to 1; bump
     /// when embedding multiple images in the same document.
-    pub fn doc_id(mut self, id: isize) -> Self {
+    ///
+    /// `wp:docPr/@id` and `pic:cNvPr/@id` are both unsigned in the
+    /// OOXML schema; `u32` matches that contract.
+    pub fn doc_id(mut self, id: u32) -> Self {
         self.doc_id = id;
         self
     }
@@ -107,14 +116,22 @@ impl<'a> Pic<'a> {
             doc_id,
         } = self;
 
-        let cx = width_emu as isize;
-        let cy = height_emu as isize;
+        // The XML uses `Option<isize>` for these fields. Saturate
+        // rather than wrap if a caller passed an absurdly large EMU
+        // value: an overflow-wrap would emit a negative cx/cy and
+        // Word would treat the picture as zero-sized or invalid.
+        let cx = isize::try_from(width_emu).unwrap_or(isize::MAX);
+        let cy = isize::try_from(height_emu).unwrap_or(isize::MAX);
+        // doc_id is u32 from the public API; widening to isize for
+        // the XML attribute is always lossless on 64-bit, and on
+        // 32-bit isize::MAX > u32::MAX/2 so values up to 2^31-1 fit.
+        let id = isize::try_from(doc_id).unwrap_or(isize::MAX);
 
         let picture = Picture {
             a: Cow::Borrowed(SCHEMA_PIC),
             nv_pic_pr: NvPicPr {
                 c_nv_pr: Some(CNvPr {
-                    id: Some(doc_id),
+                    id: Some(id),
                     name: Some(name.clone()),
                     descr: descr.clone(),
                 }),
@@ -161,7 +178,7 @@ impl<'a> Pic<'a> {
                 cy: height_emu,
             }),
             doc_property: DocPr {
-                id: Some(doc_id),
+                id: Some(id),
                 name: Some(name),
                 descr,
             },

--- a/src/media/pic.rs
+++ b/src/media/pic.rs
@@ -5,8 +5,9 @@
 //! for the common case of placing an image in a run.
 //!
 //! The helper does NOT register image bytes with the document; callers
-//! do that via [`Docx::add_image`](crate::Docx::add_image) to obtain
-//! the relationship id used here.
+//! do that via [`Docx::add_image`](crate::Docx::add_image) (raster) or
+//! [`Docx::add_svg`](crate::Docx::add_svg) (vector + raster fallback)
+//! to obtain the relationship id used here.
 //!
 //! ```no_run
 //! use docx_rust::Docx;
@@ -25,10 +26,10 @@
 use std::borrow::Cow;
 
 use crate::document::{
-    Blip, BlipFill, CNvPicPr, CNvPr, DocPr, Drawing, Ext, Extent, FillRect, Graphic, GraphicData,
-    Inline, NvPicPr, Offset, Picture, PrstGeom, SpPr, Stretch, Xfrm,
+    Blip, BlipExt, BlipExtList, BlipFill, CNvPicPr, CNvPr, DocPr, Drawing, Ext, Extent, FillRect,
+    Graphic, GraphicData, Inline, NvPicPr, Offset, Picture, PrstGeom, SpPr, Stretch, SvgBlip, Xfrm,
 };
-use crate::schema::{SCHEMA_DRAWINGML, SCHEMA_PIC};
+use crate::schema::{SCHEMA_ASVG, SCHEMA_DRAWINGML, SCHEMA_PIC, SVG_BLIP_EXT_URI};
 
 /// English Metric Units per pixel at 96 DPI.
 pub const EMU_PER_PIXEL: u64 = 9_525;
@@ -36,12 +37,27 @@ pub const EMU_PER_PIXEL: u64 = 9_525;
 /// English Metric Units per inch.
 pub const EMU_PER_INCH: u64 = 914_400;
 
+/// Identifiers for the two media parts behind a single SVG-with-fallback
+/// image. Returned by [`Docx::add_svg`](crate::Docx::add_svg) and
+/// consumed by [`Pic::with_svg`].
+#[derive(Debug, Clone)]
+pub struct SvgImageIds {
+    /// Relationship id of the SVG part. Modern Word renders this
+    /// vectorially via the `asvg:svgBlip` extension element.
+    pub svg_rid: String,
+    /// Relationship id of the PNG (or other raster) fallback part.
+    /// Legacy Word reads this; modern Word reads it too if the
+    /// extension element is missing.
+    pub png_rid: String,
+}
+
 /// Builder for an inline picture.
 ///
 /// Sizes default to 16x16 pixels at 96 DPI; override with
 /// [`Pic::size_px`] or [`Pic::size_emu`].
 pub struct Pic<'a> {
     rid: Cow<'a, str>,
+    svg_rid: Option<Cow<'a, str>>,
     name: Cow<'a, str>,
     descr: Option<Cow<'a, str>>,
     width_emu: u64,
@@ -55,6 +71,26 @@ impl<'a> Pic<'a> {
     pub fn new(rid: impl Into<Cow<'a, str>>) -> Self {
         Self {
             rid: rid.into(),
+            svg_rid: None,
+            name: Cow::Borrowed("image"),
+            descr: None,
+            width_emu: 16 * EMU_PER_PIXEL,
+            height_emu: 16 * EMU_PER_PIXEL,
+            doc_id: 1,
+        }
+    }
+
+    /// Create a builder for an SVG image with a raster fallback. The
+    /// resulting drawing carries both the standard `<a:blip>` (PNG,
+    /// for legacy Word and as a fallback) and the
+    /// `<asvg:svgBlip>` extension (SVG, for Office 2016+).
+    ///
+    /// `ids` is the value returned by
+    /// [`Docx::add_svg`](crate::Docx::add_svg).
+    pub fn with_svg(ids: SvgImageIds) -> Self {
+        Self {
+            rid: Cow::Owned(ids.png_rid),
+            svg_rid: Some(Cow::Owned(ids.svg_rid)),
             name: Cow::Borrowed("image"),
             descr: None,
             width_emu: 16 * EMU_PER_PIXEL,
@@ -109,6 +145,7 @@ impl<'a> Pic<'a> {
     pub fn into_drawing(self) -> Drawing<'a> {
         let Pic {
             rid,
+            svg_rid,
             name,
             descr,
             width_emu,
@@ -127,6 +164,16 @@ impl<'a> Pic<'a> {
         // 32-bit isize::MAX > u32::MAX/2 so values up to 2^31-1 fit.
         let id = isize::try_from(doc_id).unwrap_or(isize::MAX);
 
+        let ext_lst = svg_rid.map(|svg| BlipExtList {
+            exts: vec![BlipExt {
+                uri: Cow::Borrowed(SVG_BLIP_EXT_URI),
+                svg_blip: Some(SvgBlip {
+                    xmlns_asvg: Cow::Borrowed(SCHEMA_ASVG),
+                    embed: svg,
+                }),
+            }],
+        });
+
         let picture = Picture {
             a: Cow::Borrowed(SCHEMA_PIC),
             nv_pic_pr: NvPicPr {
@@ -141,6 +188,7 @@ impl<'a> Pic<'a> {
                 blip: Blip {
                     embed: rid,
                     cstate: None,
+                    ext_lst,
                 },
                 stretch: Some(Stretch {
                     fill_rect: Some(FillRect::default()),

--- a/src/media/svg_rasterize.rs
+++ b/src/media/svg_rasterize.rs
@@ -1,0 +1,75 @@
+//! Optional SVG rasterisation, gated on the `svg-rasterize` cargo
+//! feature. Provides [`rasterize_svg`] which turns SVG bytes into a
+//! PNG of a requested pixel size, suitable for use as the raster
+//! fallback in [`Docx::add_svg`](crate::Docx::add_svg).
+//!
+//! The default build does not include this module's dependencies —
+//! callers that already have a rasteriser (browser, ImageMagick,
+//! cairo, pre-baked assets) should keep the feature off and supply
+//! the PNG bytes themselves.
+
+use resvg::tiny_skia::{Pixmap, Transform};
+use usvg::{Options, Tree};
+
+/// Rasterise SVG bytes to a PNG of `(width_px, height_px)` size.
+///
+/// The SVG's viewBox is scaled (with aspect ratio preserved) to fit
+/// the requested pixel canvas; any leftover area is transparent. The
+/// returned bytes are a complete `image/png` blob ready to hand to
+/// [`Docx::add_svg`](crate::Docx::add_svg) as the fallback.
+pub fn rasterize_svg(
+    svg_bytes: &[u8],
+    width_px: u32,
+    height_px: u32,
+) -> Result<Vec<u8>, SvgRasterizeError> {
+    let opts = Options::default();
+    let tree = Tree::from_data(svg_bytes, &opts).map_err(SvgRasterizeError::Parse)?;
+
+    let mut pixmap = Pixmap::new(width_px, height_px).ok_or_else(|| {
+        SvgRasterizeError::Pixmap(format!("cannot allocate {}x{} pixmap", width_px, height_px))
+    })?;
+
+    let svg_size = tree.size();
+    let scale_x = width_px as f32 / svg_size.width();
+    let scale_y = height_px as f32 / svg_size.height();
+    let scale = scale_x.min(scale_y);
+    let transform = Transform::from_scale(scale, scale);
+
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+
+    pixmap
+        .encode_png()
+        .map_err(|e| SvgRasterizeError::Encode(e.to_string()))
+}
+
+/// Errors from [`rasterize_svg`].
+#[derive(Debug)]
+pub enum SvgRasterizeError {
+    /// SVG bytes failed to parse.
+    Parse(usvg::Error),
+    /// The pixmap allocator rejected the requested size.
+    Pixmap(String),
+    /// PNG encoding of the rasterised pixmap failed. The string is
+    /// the upstream encoder's error rendered with `Display`; the
+    /// concrete type is an implementation detail of `tiny-skia`.
+    Encode(String),
+}
+
+impl std::fmt::Display for SvgRasterizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(e) => write!(f, "SVG parse error: {}", e),
+            Self::Pixmap(s) => write!(f, "pixmap allocation: {}", s),
+            Self::Encode(s) => write!(f, "PNG encode error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for SvgRasterizeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(e) => Some(e),
+            Self::Pixmap(_) | Self::Encode(_) => None,
+        }
+    }
+}

--- a/src/rels.rs
+++ b/src/rels.rs
@@ -116,6 +116,44 @@ impl<'a> Relationships<'a> {
             .find(|r| r.id == id)
             .map(|r| &*r.target)
     }
+
+    /// Insert a relationship and return the assigned `rIdN`.
+    ///
+    /// If a relationship to the same target already exists, the
+    /// existing id is returned and no new entry is created.
+    ///
+    /// Unlike [`Relationships::add_rel`], this does not require the
+    /// schema and target to outlive the relationships table — owned
+    /// strings are accepted via [`Cow`].
+    pub fn add_rel_returning_id(
+        &mut self,
+        schema: impl Into<Cow<'a, str>>,
+        target: impl Into<Cow<'a, str>>,
+    ) -> String {
+        let schema = schema.into();
+        let target = target.into();
+
+        if let Some(existing) = self.relationships.iter().find(|r| r.target == target) {
+            return existing.id.to_string();
+        }
+
+        let mut id = self.relationships.len();
+        let new_id = loop {
+            id += 1;
+            let candidate = format!("rId{}", id);
+            if !self.relationships.iter().any(|r| r.id == candidate) {
+                break candidate;
+            }
+        };
+
+        self.relationships.push(Relationship {
+            id: Cow::Owned(new_id.clone()),
+            target,
+            ty: schema,
+            target_mode: None,
+        });
+        new_id
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -12,6 +12,7 @@ pub const SCHEMA_CONTENT_TYPES: &str =
 pub const SCHEMA_MAIN: &str = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 pub const SCHEMA_WORDML_14: &str = "http://schemas.microsoft.com/office/word/2010/wordml";
 pub const SCHEMA_DRAWINGML: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+pub const SCHEMA_PIC: &str = "http://schemas.openxmlformats.org/drawingml/2006/picture";
 pub const SCHEMA_WP: &str =
     "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing";
 pub const SCHEMA_RELATIONSHIPS_DOCUMENT: &str =

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -13,6 +13,13 @@ pub const SCHEMA_MAIN: &str = "http://schemas.openxmlformats.org/wordprocessingm
 pub const SCHEMA_WORDML_14: &str = "http://schemas.microsoft.com/office/word/2010/wordml";
 pub const SCHEMA_DRAWINGML: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
 pub const SCHEMA_PIC: &str = "http://schemas.openxmlformats.org/drawingml/2006/picture";
+pub const SCHEMA_ASVG: &str = "http://schemas.microsoft.com/office/drawing/2016/SVG/main";
+
+/// MS Office's stable URI marker for the SVG-blip extension. Word
+/// reads `<a:ext>` elements by URI; only this exact UUID identifies
+/// the SVG bytes as the modern-render alternative for the legacy
+/// raster `<a:blip>`.
+pub const SVG_BLIP_EXT_URI: &str = "{96DAC541-7B7A-43D3-8B79-37D633B846F1}";
 pub const SCHEMA_WP: &str =
     "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing";
 pub const SCHEMA_RELATIONSHIPS_DOCUMENT: &str =

--- a/tests/header_footer_test.rs
+++ b/tests/header_footer_test.rs
@@ -175,6 +175,76 @@ fn first_page_footer_uses_first_reference_type() {
         "first-page footer ref type missing: {}",
         doc
     );
+    // Without `<w:titlePg/>` Word silently ignores a `w:type="first"`
+    // reference. The helper must auto-add it.
+    assert!(
+        doc.contains("<w:titlePg"),
+        "first-page reference type without <w:titlePg/>: Word will ignore it. doc.xml: {}",
+        doc
+    );
+}
+
+#[test]
+fn even_page_header_writes_even_and_odd_headers_setting() {
+    let mut docx = Docx::default();
+    docx.document
+        .push(Paragraph::default().push(Run::default().push_text("body")));
+
+    let mut header = Header::default();
+    header.push(Paragraph::default().push(Run::default().push_text("even")));
+    docx.add_header_with_type(header, HeaderFooterReferenceType::Even);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    // Without `<w:evenAndOddHeaders/>` in settings.xml Word silently
+    // ignores `w:type="even"` references.
+    let settings = zip
+        .by_name("word/settings.xml")
+        .map(|mut e| {
+            let mut s = String::new();
+            std::io::Read::read_to_string(&mut e, &mut s).unwrap();
+            s
+        })
+        .expect("settings.xml must be written when an even-page reference is added");
+    assert!(
+        settings.contains("<w:evenAndOddHeaders"),
+        "evenAndOddHeaders missing from settings.xml: {}",
+        settings
+    );
+}
+
+#[test]
+fn registering_two_footers_of_the_same_type_replaces_the_old_reference() {
+    let mut docx = Docx::default();
+    docx.document
+        .push(Paragraph::default().push(Run::default().push_text("body")));
+
+    // First registration of type Default.
+    let mut a = Footer::default();
+    a.push(Paragraph::default().push(Run::default().push_text("v1")));
+    docx.add_footer(a);
+
+    // Second registration of the same type. Should replace the
+    // section reference, not stack two of them.
+    let mut b = Footer::default();
+    b.push(Paragraph::default().push(Run::default().push_text("v2")));
+    docx.add_footer(b);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+    let doc = read_part(&mut zip, "word/document.xml");
+
+    let count = doc
+        .matches(r#"<w:footerReference w:type="default""#)
+        .count();
+    assert_eq!(
+        count, 1,
+        "expected exactly one default footerReference; got {} in doc.xml: {}",
+        count, doc
+    );
 }
 
 #[test]

--- a/tests/header_footer_test.rs
+++ b/tests/header_footer_test.rs
@@ -50,7 +50,10 @@ fn add_footer_writes_part_rel_override_and_section_reference() {
     let cursor = Cursor::new(bytes.as_slice());
     let mut zip = ZipArchive::new(cursor).unwrap();
 
-    assert!(zip.by_name("word/footer1.xml").is_ok(), "footer1.xml missing");
+    assert!(
+        zip.by_name("word/footer1.xml").is_ok(),
+        "footer1.xml missing"
+    );
 
     let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
     assert!(rels.contains(r#"Target="footer1.xml""#));
@@ -111,7 +114,10 @@ fn add_header_writes_part_rel_override_and_section_reference() {
     let cursor = Cursor::new(bytes.as_slice());
     let mut zip = ZipArchive::new(cursor).unwrap();
 
-    assert!(zip.by_name("word/header1.xml").is_ok(), "header1.xml missing");
+    assert!(
+        zip.by_name("word/header1.xml").is_ok(),
+        "header1.xml missing"
+    );
 
     let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
     assert!(rels.contains(r#"Target="header1.xml""#));
@@ -196,8 +202,12 @@ fn two_footers_get_distinct_part_names() {
 #[test]
 fn run_push_tab_emits_tab_element() {
     let mut docx = Docx::default();
-    let para = Paragraph::default()
-        .push(Run::default().push_text("left").push_tab().push_text("right"));
+    let para = Paragraph::default().push(
+        Run::default()
+            .push_text("left")
+            .push_tab()
+            .push_text("right"),
+    );
     docx.document.push(para);
     let bytes = write_to_zip(&mut docx);
     let cursor = Cursor::new(bytes.as_slice());

--- a/tests/header_footer_test.rs
+++ b/tests/header_footer_test.rs
@@ -1,0 +1,207 @@
+//! End-to-end tests for header / footer ergonomics
+//! (`Docx::add_header`, `Docx::add_footer`, `page_field`,
+//! `num_pages_field`, `Run::push_tab`, and the
+//! `SCHEMA_HEADER` -> `SCHEMA_FOOTER` bug fix in the write loop).
+
+use std::io::{Cursor, Read};
+
+use docx_rust::{
+    document::{
+        num_pages_field, page_field, Footer, Header, HeaderFooterReferenceType, Paragraph, Run,
+    },
+    Docx,
+};
+use zip::ZipArchive;
+
+fn write_to_zip<'a>(docx: &'a mut Docx<'a>) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let result = docx.write(buf).expect("write docx");
+    result.into_inner()
+}
+
+fn read_part(zip: &mut ZipArchive<Cursor<&[u8]>>, name: &str) -> String {
+    let mut entry = zip.by_name(name).expect(name);
+    let mut s = String::new();
+    entry.read_to_string(&mut s).unwrap();
+    s
+}
+
+fn build_minimal_with_footer() -> Vec<u8> {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut footer = Footer::default();
+    footer.push(
+        Paragraph::default()
+            .push(Run::default().push_text("Page "))
+            .push(page_field())
+            .push(Run::default().push_text(" of "))
+            .push(num_pages_field()),
+    );
+    let _rid = docx.add_footer(footer);
+
+    write_to_zip(&mut docx)
+}
+
+#[test]
+fn add_footer_writes_part_rel_override_and_section_reference() {
+    let bytes = build_minimal_with_footer();
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(zip.by_name("word/footer1.xml").is_ok(), "footer1.xml missing");
+
+    let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
+    assert!(rels.contains(r#"Target="footer1.xml""#));
+    assert!(
+        rels.contains("/relationships/footer"),
+        "footer rel schema missing: {}",
+        rels
+    );
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(
+        cts.contains(r#"PartName="/word/footer1.xml""#)
+            && cts.contains("wordprocessingml.footer+xml"),
+        "footer Override missing: {}",
+        cts
+    );
+
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(
+        doc.contains("<w:footerReference") && doc.contains(r#"w:type="default""#),
+        "footerReference missing in sectPr: {}",
+        doc
+    );
+}
+
+#[test]
+fn footer_contains_page_and_numpages_field_codes() {
+    let bytes = build_minimal_with_footer();
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let footer = read_part(&mut zip, "word/footer1.xml");
+    assert!(footer.contains(r#"<w:fldChar w:fldCharType="begin"/>"#));
+    assert!(footer.contains(r#"<w:fldChar w:fldCharType="end"/>"#));
+    assert!(
+        footer.contains("PAGE") && footer.contains("NUMPAGES"),
+        "field instructions missing: {}",
+        footer
+    );
+    assert!(
+        footer.contains(r#"xml:space="preserve""#),
+        "instr text missing space=preserve (Word may strip leading/trailing spaces): {}",
+        footer
+    );
+}
+
+#[test]
+fn add_header_writes_part_rel_override_and_section_reference() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut header = Header::default();
+    header.push(Paragraph::default().push(Run::default().push_text("HEADER TEXT")));
+    let _rid = docx.add_header(header);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(zip.by_name("word/header1.xml").is_ok(), "header1.xml missing");
+
+    let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
+    assert!(rels.contains(r#"Target="header1.xml""#));
+    assert!(rels.contains("/relationships/header"));
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(cts.contains(r#"PartName="/word/header1.xml""#));
+    assert!(cts.contains("wordprocessingml.header+xml"));
+
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(doc.contains("<w:headerReference"));
+}
+
+#[test]
+fn header_and_footer_can_coexist_in_one_section() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut header = Header::default();
+    header.push(Paragraph::default().push(Run::default().push_text("H")));
+    let h_rid = docx.add_header(header);
+
+    let mut footer = Footer::default();
+    footer.push(Paragraph::default().push(Run::default().push_text("F")));
+    let f_rid = docx.add_footer(footer);
+
+    assert_ne!(h_rid, f_rid, "header and footer rids must differ");
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(doc.contains("<w:headerReference"));
+    assert!(doc.contains("<w:footerReference"));
+}
+
+#[test]
+fn first_page_footer_uses_first_reference_type() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut footer = Footer::default();
+    footer.push(Paragraph::default().push(Run::default().push_text("first-page-only")));
+    docx.add_footer_with_type(footer, HeaderFooterReferenceType::First);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(
+        doc.contains(r#"<w:footerReference w:type="first""#),
+        "first-page footer ref type missing: {}",
+        doc
+    );
+}
+
+#[test]
+fn two_footers_get_distinct_part_names() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default().push(Run::default().push_text("body"));
+    docx.document.push(para);
+
+    let mut a = Footer::default();
+    a.push(Paragraph::default().push(Run::default().push_text("default")));
+    docx.add_footer(a);
+
+    let mut b = Footer::default();
+    b.push(Paragraph::default().push(Run::default().push_text("first")));
+    docx.add_footer_with_type(b, HeaderFooterReferenceType::First);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(zip.by_name("word/footer1.xml").is_ok());
+    assert!(zip.by_name("word/footer2.xml").is_ok());
+}
+
+#[test]
+fn run_push_tab_emits_tab_element() {
+    let mut docx = Docx::default();
+    let para = Paragraph::default()
+        .push(Run::default().push_text("left").push_tab().push_text("right"));
+    docx.document.push(para);
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(doc.contains("<w:tab/>"), "expected <w:tab/>: {}", doc);
+}

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -1,0 +1,131 @@
+//! End-to-end tests for the image-embedding ergonomics
+//! (`Docx::add_image`, `Pic`, `Run::push_image`).
+//!
+//! Tests serialise the document into an in-memory zip, then parse the
+//! resulting parts as XML to assert presence of relationships, content
+//! types, and the drawing chain.
+
+use std::io::Cursor;
+
+use docx_rust::{
+    document::{Paragraph, Run},
+    media::{MediaType, Pic},
+    Docx,
+};
+use zip::ZipArchive;
+
+/// Smallest valid PNG (1x1 transparent).
+const PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0x0F, 0x04, 0x00,
+    0x00, 0x09, 0xFB, 0x03, 0xFD, 0x8E, 0xB8, 0x8C, 0x7E, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+fn write_to_zip<'a>(docx: &'a mut Docx<'a>) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let result = docx.write(buf).expect("write docx");
+    result.into_inner()
+}
+
+fn read_part(zip: &mut ZipArchive<Cursor<&[u8]>>, name: &str) -> String {
+    use std::io::Read;
+    let mut entry = zip.by_name(name).expect(name);
+    let mut s = String::new();
+    entry.read_to_string(&mut s).unwrap();
+    s
+}
+
+#[test]
+fn single_image_registers_media_rel_and_content_type() {
+    let png = PNG.to_vec();
+    let mut docx = Docx::default();
+
+    let rid = docx.add_image("dot.png", MediaType::Image, &png);
+    let drawing = Pic::new(rid.clone()).size_px(16, 16).into_drawing();
+    let para = Paragraph::default().push(Run::default().push_image(drawing));
+    docx.document.push(para);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(
+        zip.by_name("word/media/dot.png").is_ok(),
+        "image bytes missing from zip"
+    );
+
+    let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
+    assert!(
+        rels.contains(&format!(r#"Id="{}""#, rid)),
+        "rel id {} missing in {}",
+        rid,
+        rels
+    );
+    assert!(rels.contains(r#"Target="media/dot.png""#));
+    assert!(rels.contains("/relationships/image"));
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(
+        cts.contains(r#"Extension="png""#) && cts.contains(r#"ContentType="image/png""#),
+        "png Default not registered: {}",
+        cts
+    );
+
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(doc.contains(r#"r:embed="rId1""#) || doc.contains(&format!(r#"r:embed="{}""#, rid)));
+    assert!(doc.contains("<w:drawing>"));
+    assert!(doc.contains("<pic:pic"));
+}
+
+#[test]
+fn ten_images_get_distinct_rids_and_one_content_type() {
+    let png = PNG.to_vec();
+    let mut docx = Docx::default();
+
+    let mut rids = Vec::new();
+    for i in 0..10 {
+        let name = format!("img{}.png", i);
+        let rid = docx.add_image(name, MediaType::Image, &png);
+        rids.push(rid.clone());
+        let drawing = Pic::new(rid).doc_id(i + 1).into_drawing();
+        let para = Paragraph::default().push(Run::default().push_image(drawing));
+        docx.document.push(para);
+    }
+
+    let unique: std::collections::HashSet<_> = rids.iter().collect();
+    assert_eq!(unique.len(), 10, "rids must be distinct: {:?}", rids);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    let png_default_count = cts.matches(r#"Extension="png""#).count();
+    assert_eq!(png_default_count, 1, "png Default duplicated: {}", cts);
+}
+
+#[test]
+fn jpeg_extension_registers_image_jpeg_content_type() {
+    let bytes = vec![0xFF, 0xD8, 0xFF, 0xE0]; // not a valid JPEG but irrelevant for the test
+    let mut docx = Docx::default();
+    let _rid = docx.add_image("photo.jpg", MediaType::Image, &bytes);
+
+    let zip_bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(zip_bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(cts.contains(r#"Extension="jpg""#));
+    assert!(cts.contains(r#"ContentType="image/jpeg""#));
+}
+
+#[test]
+fn pic_size_px_converts_to_emu() {
+    let drawing = Pic::new("rId99").size_px(100, 50).into_drawing();
+    let inline = drawing.inline.expect("inline");
+    let extent = inline.extent.expect("extent");
+    assert_eq!(extent.cx, 100 * 9_525);
+    assert_eq!(extent.cy, 50 * 9_525);
+}

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -74,7 +74,12 @@ fn single_image_registers_media_rel_and_content_type() {
     );
 
     let doc = read_part(&mut zip, "word/document.xml");
-    assert!(doc.contains(r#"r:embed="rId1""#) || doc.contains(&format!(r#"r:embed="{}""#, rid)));
+    assert!(
+        doc.contains(&format!(r#"r:embed="{}""#, rid)),
+        "drawing chain must embed the rid returned by add_image ({}); doc.xml: {}",
+        rid,
+        doc
+    );
     assert!(doc.contains("<w:drawing>"));
     assert!(doc.contains("<pic:pic"));
 }

--- a/tests/svg_test.rs
+++ b/tests/svg_test.rs
@@ -1,0 +1,161 @@
+//! End-to-end tests for SVG-with-fallback embedding via
+//! `Docx::add_svg` + `Pic::with_svg`. The XML output must carry both
+//! a standard `<a:blip r:embed="...">` (PNG fallback for legacy Word)
+//! and an `<asvg:svgBlip r:embed="...">` extension (SVG for modern
+//! Word), with distinct relationship ids.
+
+use std::io::{Cursor, Read};
+
+use docx_rust::{
+    document::{Paragraph, Run},
+    media::{MediaType, Pic, SvgImageIds},
+    Docx,
+};
+use zip::ZipArchive;
+
+/// Smallest valid PNG (1x1 transparent). Structural-only; rendering
+/// is irrelevant to these tests.
+const PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0x0F, 0x04, 0x00,
+    0x00, 0x09, 0xFB, 0x03, 0xFD, 0x8E, 0xB8, 0x8C, 0x7E, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+const SVG: &[u8] =
+    br#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="14" fill="red"/></svg>"#;
+
+fn write_to_zip<'a>(docx: &'a mut Docx<'a>) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let result = docx.write(buf).expect("write docx");
+    result.into_inner()
+}
+
+fn read_part(zip: &mut ZipArchive<Cursor<&[u8]>>, name: &str) -> String {
+    let mut entry = zip.by_name(name).expect(name);
+    let mut s = String::new();
+    entry.read_to_string(&mut s).unwrap();
+    s
+}
+
+#[test]
+fn add_svg_writes_both_parts_and_both_rels_and_both_content_types() {
+    let svg = SVG.to_vec();
+    let png = PNG.to_vec();
+    let mut docx = Docx::default();
+
+    let ids: SvgImageIds = docx.add_svg("logo", &svg, &png);
+    assert_ne!(ids.svg_rid, ids.png_rid, "rids must differ");
+
+    let drawing = Pic::with_svg(ids.clone()).size_px(64, 64).into_drawing();
+    let para = Paragraph::default().push(Run::default().push_image(drawing));
+    docx.document.push(para);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    assert!(
+        zip.by_name("word/media/logo.svg").is_ok(),
+        "svg part missing"
+    );
+    assert!(
+        zip.by_name("word/media/logo.png").is_ok(),
+        "png part missing"
+    );
+
+    let rels = read_part(&mut zip, "word/_rels/document.xml.rels");
+    assert!(rels.contains(r#"Target="media/logo.svg""#));
+    assert!(rels.contains(r#"Target="media/logo.png""#));
+    assert!(rels.contains(&format!(r#"Id="{}""#, ids.svg_rid)));
+    assert!(rels.contains(&format!(r#"Id="{}""#, ids.png_rid)));
+
+    let cts = read_part(&mut zip, "[Content_Types].xml");
+    assert!(
+        cts.contains(r#"Extension="svg""#) && cts.contains(r#"ContentType="image/svg+xml""#),
+        "svg Default missing: {}",
+        cts
+    );
+    assert!(cts.contains(r#"Extension="png""#));
+}
+
+#[test]
+fn drawing_xml_carries_both_blip_and_svg_blip_extension() {
+    let svg = SVG.to_vec();
+    let png = PNG.to_vec();
+    let mut docx = Docx::default();
+
+    let ids = docx.add_svg("logo", &svg, &png);
+    let png_rid = ids.png_rid.clone();
+    let svg_rid = ids.svg_rid.clone();
+    let drawing = Pic::with_svg(ids).size_px(64, 64).into_drawing();
+    let para = Paragraph::default().push(Run::default().push_image(drawing));
+    docx.document.push(para);
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+
+    let doc = read_part(&mut zip, "word/document.xml");
+
+    // Standard blip points at the PNG fallback.
+    assert!(
+        doc.contains(&format!(r#"<a:blip r:embed="{}""#, png_rid)),
+        "standard a:blip should embed the PNG rid: {}",
+        doc
+    );
+
+    // Extension list with SVG-blip URI.
+    assert!(doc.contains("<a:extLst>"), "a:extLst missing");
+    assert!(
+        doc.contains("{96DAC541-7B7A-43D3-8B79-37D633B846F1}"),
+        "SVG ext URI missing: {}",
+        doc
+    );
+
+    // SVG blip points at the SVG rid.
+    assert!(
+        doc.contains(&format!(r#"r:embed="{}""#, svg_rid)),
+        "asvg:svgBlip should embed the SVG rid: {}",
+        doc
+    );
+    assert!(doc.contains("<asvg:svgBlip"), "<asvg:svgBlip> tag missing");
+    assert!(
+        doc.contains("xmlns:asvg=\"http://schemas.microsoft.com/office/drawing/2016/SVG/main\""),
+        "asvg namespace declaration missing: {}",
+        doc
+    );
+}
+
+#[test]
+fn raster_only_image_does_not_emit_svg_extension() {
+    let png = PNG.to_vec();
+    let mut docx = Docx::default();
+    let rid = docx.add_image("plain.png", MediaType::Image, &png);
+    let drawing = Pic::new(rid).size_px(32, 32).into_drawing();
+    docx.document
+        .push(Paragraph::default().push(Run::default().push_image(drawing)));
+
+    let bytes = write_to_zip(&mut docx);
+    let cursor = Cursor::new(bytes.as_slice());
+    let mut zip = ZipArchive::new(cursor).unwrap();
+    let doc = read_part(&mut zip, "word/document.xml");
+    assert!(
+        !doc.contains("<a:extLst>"),
+        "plain raster path should not emit a:extLst"
+    );
+    assert!(!doc.contains("<asvg:svgBlip"));
+}
+
+#[cfg(feature = "svg-rasterize")]
+#[test]
+fn rasterize_svg_produces_valid_png_bytes() {
+    let bytes = docx_rust::media::rasterize_svg(SVG, 64, 64).expect("rasterise");
+    assert!(bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]), "not a PNG");
+    // Sanity-check the rasterised PNG round-trips through add_svg.
+    let svg = SVG.to_vec();
+    let mut docx = Docx::default();
+    let ids = docx.add_svg("logo", &svg, &bytes);
+    assert_ne!(ids.svg_rid, ids.png_rid);
+}


### PR DESCRIPTION
**Stacked on top of #55 and #56.** Please review those first; the first three commits on this branch are identical to those PRs. After they merge, this rebases cleanly to a single commit.

## Why

Word 2016+ supports SVG natively, but only via a specific extension shape: a standard `<a:blip>` pointing at a PNG (the legacy fallback) wraps an `<a:extLst>` carrying an `<asvg:svgBlip>` extension element pointing at the SVG part. Modern Word renders the SVG vectorially; older Word ignores the extension and falls back to the PNG. Microsoft's own Office implementations emit exactly this shape.

This PR adds first-class SVG support that produces the correct extension XML, registers both media parts, both relationships, and both Content Types Defaults.

## API

\`\`\`rust
use docx_rust::{Docx, document::{Paragraph, Run}, media::Pic};

let svg = std::fs::read(\"logo.svg\")?;
let png = std::fs::read(\"logo-fallback.png\")?;   // pre-rasterised at desired size

let mut docx = Docx::default();
let ids = docx.add_svg(\"logo\", &svg, &png);
let drawing = Pic::with_svg(ids).size_px(120, 60).into_drawing();
docx.document.push(Paragraph::default().push(Run::default().push_image(drawing)));
\`\`\`

For one-call convenience an opt-in cargo feature \`svg-rasterize\` pulls in \`resvg\` + \`usvg\` + \`tiny-skia\` and exposes a free \`rasterize_svg(svg, w, h) -> Vec<u8>\`. Off by default; the runtime dependency surface of a default \`docx-rust\` build does not change.

## What's added

- **Drawing XML types** (\`src/document/drawing.rs\`): \`BlipExtList\`, \`BlipExt\`, \`SvgBlip\`. \`Blip\` extended with optional \`ext_lst\` child.
- **Schema constants** (\`src/schema.rs\`): \`SCHEMA_ASVG\` and \`SVG_BLIP_EXT_URI\`. The latter is the \`{96DAC541-7B7A-43D3-8B79-37D633B846F1}\` marker Word uses to recognise the SVG variant.
- **\`Pic::with_svg(SvgImageIds)\`** builder variant. The standard \`Pic::new\` raster-only path remains unchanged and emits no \`ext_lst\` — confirmed by a regression test.
- **\`Docx::add_svg(name_stem, svg_bytes, png_fallback_bytes) -> SvgImageIds\`** registers both media parts (\`media/<stem>.svg\` and \`media/<stem>.png\`), allocates two relationship ids, registers both Content Types \`<Default>\` entries, and returns the rid pair.
- **\`media::SvgImageIds\`** struct (\`svg_rid\`, \`png_rid\`) for clarity over a \`(String, String)\` tuple.
- **Content Types extension**: \`ensure_image_content_type\` now maps \`svg\` -> \`image/svg+xml\`. \`get_media_type\` now recognises svg / gif / tif / tiff alongside png / jpg / jpeg / bmp.

## Optional feature

\`\`\`toml
[features]
svg-rasterize = [\"dep:resvg\", \"dep:tiny-skia\", \"dep:usvg\"]
\`\`\`

When enabled, exposes \`docx_rust::media::rasterize_svg\`. Errors via \`SvgRasterizeError\` (\`Parse\` / \`Pixmap\` / \`Encode\`).

## Tests

\`tests/svg_test.rs\` — 3 default tests + 1 feature-gated:

1. \`add_svg\` writes both zip parts, both rels with distinct rIds, both Content Types \`<Default>\` entries.
2. The drawing XML carries the standard \`<a:blip>\` (PNG embed) PLUS an \`<a:extLst>\` with the SVG ext URI and a \`<asvg:svgBlip>\` child whose namespace declaration and \`r:embed\` are correct.
3. Regression: the raster-only \`Pic::new\` path emits no \`<a:extLst>\` and no \`<asvg:svgBlip>\` — i.e., adding SVG support did not pollute existing image output.
4. (feature) \`rasterize_svg\` produces valid PNG bytes (PNG signature) that round-trip through \`add_svg\`.

\`examples/svg.rs\` (caller-supplied) and \`examples/svg_auto.rs\` (cfg-gated on the feature). Default-feature build of \`svg_auto\` prints a hint instead of compiling the rasteriser path, keeping the no-feature build honest.

All 146 default tests pass. With \`--features svg-rasterize\`: 147.